### PR TITLE
Bug fix: correct the  cell optimisation with constrained ratios

### DIFF
--- a/src/move_atoms.module.f90
+++ b/src/move_atoms.module.f90
@@ -4041,6 +4041,8 @@ contains
   !!  CREATION DATE
   !!   30/05/17
   !!  MODIFICATION HISTORY
+  !!   2020/04/24 08:15 dave
+  !!    Bug fix for constrained ratios
   !!  SOURCE
   !!
   subroutine update_cell_dims(start_rcellx, start_rcelly, start_rcellz, &
@@ -4121,18 +4123,30 @@ contains
         rcellx = start_rcellx + k * search_dir_x
 
     ! Fix a single ratio?
-    else if (leqi(cell_constraint_flag, 'c/a') .or. leqi(cell_constraint_flag, 'a/c')) then
-        rcellx = start_rcellx + k * (start_rcellx/start_rcellz)*search_dir_z
-        rcelly = start_rcelly + k * search_dir_y
-        rcellz = start_rcellz + k * (start_rcellz/start_rcellx)*search_dir_x
-    else if (leqi(cell_constraint_flag, 'a/b') .or. leqi(cell_constraint_flag, 'b/a')) then
-        rcellx = start_rcellx + k * (start_rcellx/start_rcelly)*search_dir_y
-        rcelly = start_rcelly + k * (start_rcelly/start_rcellx)*search_dir_x
-        rcellz = start_rcellz + k * search_dir_z
-    else if (leqi(cell_constraint_flag, 'b/c') .or. leqi(cell_constraint_flag, 'c/b')) then
-        rcellx = start_rcellx + k * search_dir_x
-        rcelly = start_rcelly + k * (start_rcelly/start_rcellz)*search_dir_z
-        rcellz = start_rcellz + k * (start_rcellz/start_rcelly)*search_dir_y
+    else if (leqi(cell_constraint_flag, 'a/c')) then
+       rcellx = start_rcellx + k * (start_rcellx/start_rcellz)*search_dir_z
+       rcelly = start_rcelly + k * search_dir_y
+       rcellz = start_rcellz + k * search_dir_z
+    else if (leqi(cell_constraint_flag, 'c/a')) then
+       rcellx = start_rcellx + k * search_dir_x
+       rcelly = start_rcelly + k * search_dir_y
+       rcellz = start_rcellz + k * (start_rcellz/start_rcellx)*search_dir_x
+    else if (leqi(cell_constraint_flag, 'a/b')) then
+       rcellx = start_rcellx + k * (start_rcellx/start_rcelly)*search_dir_y
+       rcelly = start_rcelly + k * search_dir_y
+       rcellz = start_rcellz + k * search_dir_z
+    else if (leqi(cell_constraint_flag, 'b/a')) then
+       rcellx = start_rcellx + k * search_dir_x
+       rcelly = start_rcelly + k * (start_rcelly/start_rcellx)*search_dir_x
+       rcellz = start_rcellz + k * search_dir_z
+    else if (leqi(cell_constraint_flag, 'b/c')) then
+       rcellx = start_rcellx + k * search_dir_x
+       rcelly = start_rcelly + k * (start_rcelly/start_rcellz)*search_dir_z
+       rcellz = start_rcellz + k * search_dir_z
+    else if (leqi(cell_constraint_flag, 'c/b')) then
+       rcellx = start_rcellx + k * search_dir_x
+       rcelly = start_rcelly + k * search_dir_y
+       rcellz = start_rcellz + k * (start_rcellz/start_rcelly)*search_dir_y
     end if
 
     r_super_x = rcellx

--- a/src/move_atoms.module.f90
+++ b/src/move_atoms.module.f90
@@ -4043,6 +4043,8 @@ contains
   !!  MODIFICATION HISTORY
   !!   2020/04/24 08:15 dave
   !!    Bug fix for constrained ratios
+  !!   2020/05/15 12:26 dave
+  !!    Update to remove unnecessary code (a/c and c/a etc are the same)
   !!  SOURCE
   !!
   subroutine update_cell_dims(start_rcellx, start_rcelly, start_rcellz, &
@@ -4123,27 +4125,15 @@ contains
         rcellx = start_rcellx + k * search_dir_x
 
     ! Fix a single ratio?
-    else if (leqi(cell_constraint_flag, 'a/c')) then
-       rcellx = start_rcellx + k * (start_rcellx/start_rcellz)*search_dir_z
-       rcelly = start_rcelly + k * search_dir_y
-       rcellz = start_rcellz + k * search_dir_z
-    else if (leqi(cell_constraint_flag, 'c/a')) then
+    else if (leqi(cell_constraint_flag, 'a/c') .OR. leqi(cell_constraint_flag, 'c/a')) then
        rcellx = start_rcellx + k * search_dir_x
        rcelly = start_rcelly + k * search_dir_y
        rcellz = start_rcellz + k * (start_rcellz/start_rcellx)*search_dir_x
-    else if (leqi(cell_constraint_flag, 'a/b')) then
-       rcellx = start_rcellx + k * (start_rcellx/start_rcelly)*search_dir_y
-       rcelly = start_rcelly + k * search_dir_y
-       rcellz = start_rcellz + k * search_dir_z
-    else if (leqi(cell_constraint_flag, 'b/a')) then
+    else if (leqi(cell_constraint_flag, 'a/b') .OR. leqi(cell_constraint_flag, 'b/a')) then
        rcellx = start_rcellx + k * search_dir_x
        rcelly = start_rcelly + k * (start_rcelly/start_rcellx)*search_dir_x
        rcellz = start_rcellz + k * search_dir_z
-    else if (leqi(cell_constraint_flag, 'b/c')) then
-       rcellx = start_rcellx + k * search_dir_x
-       rcelly = start_rcelly + k * (start_rcelly/start_rcellz)*search_dir_z
-       rcellz = start_rcellz + k * search_dir_z
-    else if (leqi(cell_constraint_flag, 'c/b')) then
+    else if (leqi(cell_constraint_flag, 'b/c') .OR. leqi(cell_constraint_flag, 'c/b')) then
        rcellx = start_rcellx + k * search_dir_x
        rcelly = start_rcelly + k * search_dir_y
        rcellz = start_rcellz + k * (start_rcellz/start_rcelly)*search_dir_y


### PR DESCRIPTION
The original version combined c/a and a/c into a single case,
which gave the wrong behaviour.  Now separated into individual
cases.