### PR TITLE
Change default for perturbative polarisation

### DIFF
--- a/tools/BasisGeneration/read_module.f90
+++ b/tools/BasisGeneration/read_module.f90
@@ -103,6 +103,7 @@ contains
     ! Local variables
     character(len=80) :: input_string
     integer :: i
+    logical :: flag_default
     
     if(fdf_block(species_label(species))) then
        !
@@ -127,34 +128,6 @@ contains
        alpha = fdf_double("Mesh.Alpha",alpha)
        beta = fdf_double("Mesh.Beta",beta)
        delta_r_reg = fdf_double("Atom.RegularSpacing",0.01_double)       
-       !
-       ! Polarisation
-       !
-       paos%flag_perturb_polarise = fdf_boolean("Atom.Perturbative_Polarised",.true.)
-       if(paos%flag_perturb_polarise) then
-          ! This is for compatibility but should be false
-          flag_use_Vl = fdf_boolean('Atom.UseVl',flag_gen_use_Vl)
-          ! Do we have state to polarise? 
-          paos%polarised_n = fdf_integer("Atom.PolarisedN",0)
-          paos%polarised_l = fdf_integer("Atom.PolarisedL",-1)
-          paos%polarised_shell = 0
-          !
-          ! Default to outer shell (or previous if outer shell has l=2)
-          !
-          if(paos%polarised_n==0.AND.paos%polarised_l==-1) then
-             ! Outer-most occupied shell
-             i = val%n_occ
-             ! If it is l=2 (or more!) then default to one lower
-             if(val%l(i)>1) i = i-1
-             if(i==0) &
-                  call cq_abort("We have one shell with l=2; I can't polarise this automatically.")
-             paos%polarised_n = val%n(i)
-             paos%polarised_l = val%l(i)
-             paos%polarised_shell = i
-             write(*,fmt='(4x,"Polarising shell ",i2," with n=",i2," and l=",i2)') &
-                  i, paos%polarised_n, paos%polarised_l
-          end if
-       end if
        !
        ! Form for zetas: compress or split norm
        !
@@ -240,6 +213,39 @@ contains
           ! Close species block
           call fdf_endblock
           flag_default_cutoffs = .true.
+       end if
+       !
+       ! Polarisation
+       !
+       flag_default = .true.
+       ! If there are no polarisation orbitals, change default
+       if(basis_size == minimal .or. paos%n_shells==val%n_occ) flag_default = .false.
+       paos%flag_perturb_polarise = fdf_boolean("Atom.Perturbative_Polarised",flag_default)
+       if(paos%flag_perturb_polarise .and. flag_default) then
+          ! This is for compatibility but should be false
+          flag_use_Vl = fdf_boolean('Atom.UseVl',flag_gen_use_Vl)
+          ! Do we have state to polarise? 
+          paos%polarised_n = fdf_integer("Atom.PolarisedN",0)
+          paos%polarised_l = fdf_integer("Atom.PolarisedL",-1)
+          paos%polarised_shell = 0
+          !
+          ! Default to outer shell (or previous if outer shell has l=2)
+          !
+          if(paos%polarised_n==0.AND.paos%polarised_l==-1) then
+             ! Outer-most occupied shell
+             i = val%n_occ
+             ! If it is l=2 (or more!) then default to one lower
+             if(val%l(i)>1) i = i-1
+             if(i==0) &
+                  call cq_abort("We have one shell with l=2; I can't polarise this automatically.")
+             paos%polarised_n = val%n(i)
+             paos%polarised_l = val%l(i)
+             paos%polarised_shell = i
+             write(*,fmt='(4x,"Polarising shell ",i2," with n=",i2," and l=",i2)') &
+                  i, paos%polarised_n, paos%polarised_l
+          end if
+       else if(paos%flag_perturb_polarise .and. (.not.flag_default)) then
+          call cq_abort("Can't set Atom.Perturbative_Polarised T with no polarisation orbitals")
        end if
     else
        call cq_abort("Can't find species block for label "//species_label(species))


### PR DESCRIPTION
We now test for whether there are polarisation orbitals before
reading the flag; if there are not, then we set the default to
false, and abort if the user selects true.  This fixes a
cosmetic issue (where minimal basis functions were labelled
as polarisation though they weren't).

Closes #54 