### PR TITLE
A small bug in biblio_module

### DIFF
--- a/src/biblio_module.f90
+++ b/src/biblio_module.f90
@@ -122,6 +122,7 @@ contains
     integer :: lun
     character(len=400)                :: str
 
+   if(inode == ionode) then
     call io_assign(lun) 
     if (first) then
        open(unit=lun,file=bibtex_file,status='replace')
@@ -141,6 +142,8 @@ contains
     write(lun,'("}")')
 
     call io_close(lun)
+
+   endif !(inode == ionode) 
 
   end subroutine write_bib
   !!***


### PR DESCRIPTION
…io_assign" etc.

In "write_bib", I put "if(inode == ionode)" as the subroutine calls "io_assign" etc.
At present, all processes call io_assign, and try to write information to the file simultaneously, I think.
For debugging, it is also possible to call "write_bib" only from inode. 
(But, I thought it is safer to have if-clause here.)