### PR TITLE
Fix DFT energy

### DIFF
--- a/src/SelfCon_module.f90
+++ b/src/SelfCon_module.f90
@@ -1548,6 +1548,8 @@ contains
   !!    Add option to allow LFD at each SCF step
   !!   2021/07/26 11:49 dave
   !!    Fix module use for get_H_matrix
+  !!   2021/07/28 10:13 dave
+  !!    Correctly calculate DFT energy (Ha, XC and local contributions use output density)
   !!  SOURCE
   !!
   subroutine get_new_rho(record, reset_L, fixed_potential, vary_mu,  &
@@ -1621,13 +1623,6 @@ contains
                                    dontM1,  dontM2, dontM3, dontM4,  &
                                    dontphi, dontE, level=backtrace_level)
        end if
-       ! Get total energy
-       if (flag_check_DFT) then
-          call get_energy(total_energy=total_energy,printDFT=.false., &
-               level=backtrace_level)
-       else
-          call get_energy(total_energy=total_energy,level=backtrace_level)
-       endif
     end if ! if (flag_perform_cDFT) then
 
     ! And get the output density
@@ -1638,13 +1633,10 @@ contains
     call start_timer(tmr_std_chargescf)
     call free_temp_fn_on_grid(temp_supp_fn)
 
-    !For DFT energy with charge density constructed by density matrix --
-    !TM Nov2007
-    if (flag_check_DFT) then
-       ! Find Hartree, XC and local PS (i.e. NA) energies with output density
-       call get_output_energies(rhoout, size)
-       call get_energy(total_energy, flag_check_DFT, backtrace_level)
-    endif
+    ! Now build DFT energy from output charge
+    ! Find Hartree, XC and local PS (i.e. NA) energies with output density
+    call get_output_energies(rhoout, size)
+    call get_energy(total_energy, .true., backtrace_level) ! Output DFT energy
 
 !****lat<$
     call stop_backtrace(t=backtrace_timer,who='get_new_rho',echo=.true.)

--- a/src/SelfCon_module.f90
+++ b/src/SelfCon_module.f90
@@ -1558,7 +1558,7 @@ contains
     use DMMin,             only: FindMinDM
     use global_module,     only: iprint_SC, atomf, flag_perform_cDFT, &
                                  nspin, spin_factor, flag_diagonalisation, flag_LFD, flag_Multisite
-    use H_matrix_module,   only: get_H_matrix
+    use H_matrix_module,   only: get_output_energies
     use S_matrix_module,   only: get_S_matrix
     !use DiagModule,        only: diagon
     use energy,            only: get_energy, flag_check_DFT
@@ -1639,7 +1639,8 @@ contains
     !For DFT energy with charge density constructed by density matrix --
     !TM Nov2007
     if (flag_check_DFT) then
-       call get_H_matrix(.false., fixed_potential, electrons, rhoout, size)
+       ! Find Hartree, XC and local PS (i.e. NA) energies with output density
+       call get_output_energies(rhoout, size)
        call get_energy(total_energy, flag_check_DFT, backtrace_level)
     endif
 

--- a/src/SelfCon_module.f90
+++ b/src/SelfCon_module.f90
@@ -1565,7 +1565,7 @@ contains
     use H_matrix_module,   only: get_H_matrix, get_output_energies
     use S_matrix_module,   only: get_S_matrix
     !use DiagModule,        only: diagon
-    use energy,            only: get_energy, flag_check_DFT
+    use energy,            only: get_energy
     use functions_on_grid, only: atomfns, allocate_temp_fn_on_grid, &
                                  free_temp_fn_on_grid
     use density_module,    only: get_electronic_density

--- a/src/SelfCon_module.f90
+++ b/src/SelfCon_module.f90
@@ -1546,6 +1546,8 @@ contains
   !!    - Changing location of diagon flag from DiagModule to global and name to flag_diagonalisation
   !!   2020/08/24 11:21 dave
   !!    Add option to allow LFD at each SCF step
+  !!   2021/07/26 11:49 dave
+  !!    Fix module use for get_H_matrix
   !!  SOURCE
   !!
   subroutine get_new_rho(record, reset_L, fixed_potential, vary_mu,  &
@@ -1558,7 +1560,7 @@ contains
     use DMMin,             only: FindMinDM
     use global_module,     only: iprint_SC, atomf, flag_perform_cDFT, &
                                  nspin, spin_factor, flag_diagonalisation, flag_LFD, flag_Multisite
-    use H_matrix_module,   only: get_output_energies
+    use H_matrix_module,   only: get_H_matrix, get_output_energies
     use S_matrix_module,   only: get_S_matrix
     !use DiagModule,        only: diagon
     use energy,            only: get_energy, flag_check_DFT
@@ -1599,7 +1601,7 @@ contains
        call initial_SFcoeff(.false.,.false.,fixed_potential,.false.)
        call get_S_matrix(inode, ionode, build_AtomF_matrix=.false.)
        call get_H_matrix(.false., fixed_potential, electrons, rhoin, &
-            size, backtrace_level,.false.)
+            size, level=backtrace_level,build_AtomF_matrix=.false.)
     end if
     if (flag_perform_cDFT) then
        call cdft_min(reset_L, fixed_potential, vary_mu, &

--- a/src/XC_CQ_module.f90
+++ b/src/XC_CQ_module.f90
@@ -31,6 +31,8 @@
 !!    Added spin_factor in module use statements
 !!   2019/04/08 zamaan
 !!    Added off-diagonal elements of XC stress tensor contributions
+!!   2021/07/22 14:26 dave
+!!    Added get_xc_energy routine (and associated)
 !! SOURCE
 !!
 module XC
@@ -52,7 +54,7 @@ module XC
   logical, public :: flag_different_functional
 
   ! Public methods
-  public :: get_xc_potential, get_dxc_potential, init_xc
+  public :: get_xc_potential, get_dxc_potential, init_xc, get_xc_energy
 
   ! Conquest functional identifiers
   integer, parameter :: functional_lda_pz81        = 1
@@ -1908,484 +1910,544 @@ contains
   end subroutine get_xc_potential_hyb_PBE0
   !!*****
 
-
-  !!****f* XC_module/get_xc_potential_GGA_PBE_obsolete *
+  !!****f* XC/get_xc_energy *
   !!
   !!  NAME
-  !!   get_xc_potential_GGA_PBE_obsolete
+  !!   get_xc_energy
   !!  USAGE
   !!
   !!  PURPOSE
-  !!   Calculates the exchange-correlation potential
-  !!   on the grid within GGA using the
-  !!   Perdew-Burke-Ernzerhof. It also calculates the
-  !!   total exchange-correlation energy.
+  !!   Interface to CQ routines
+  !!  INPUTS
   !!
-  !!   Note that this is the functional described in
-  !!   Phys. Rev. Lett. 77, 3865 (1996)
+  !!  USES
   !!
-  !!   It is also (depending on an optional parameter)
-  !!     either revPBE, Phys. Rev. Lett. 80, 890 (1998),
-  !!     or RPBE, Phys. Rev. B 59, 7413 (1999)
+  !!  AUTHOR
+  !!   D. R. Bowler
+  !!  CREATION DATE
+  !!   2021/07/22
+  !!  MODIFICATION HISTORY
+  !!  SOURCE
+  !!
+  subroutine get_xc_energy(density, xc_energy, size)
+
+    use datatypes
+    use numbers
+    use global_module,               only: exx_niter, exx_siter, exx_alpha, nspin
+
+    implicit none
+
+    ! Passed variables
+    integer                    :: size
+    real(double)               :: xc_energy
+    real(double), dimension(size,nspin) :: density
+
+    ! Local variables
+    real(double) :: loc_x_energy, exx_tmp
+
+    select case(flag_functional_type)
+    case (functional_lda_pz81)
+       ! NOT SPIN POLARISED
+       call get_xc_energy_LDA_PZ81(density(:,1), xc_energy, size)
+       !
+       !
+    case (functional_lda_gth96)
+       ! NOT SPIN POLARISED
+       call get_GTH_xc_energy(density(:,1), xc_energy, size)
+       !
+       !
+    case (functional_lda_pw92)
+       call get_xc_energy_LSDA_PW92(density, xc_energy, size)
+       !
+       !
+    case (functional_gga_pbe96)
+       call get_xc_energy_GGA_PBE(density, xc_energy, size)
+       !
+       !
+    case (functional_gga_pbe96_rev98)
+       call get_xc_energy_GGA_PBE(density, xc_energy, size, functional_gga_pbe96_rev98 )
+       !
+       !
+    case (functional_gga_pbe96_r99)
+       call get_xc_energy_GGA_PBE(density, xc_energy, size, functional_gga_pbe96_r99 )
+       !
+       !
+    case (functional_gga_pbe96_wc)
+       call get_xc_energy_GGA_PBE(density, xc_energy, size, functional_gga_pbe96_wc )
+       !
+       !
+    case (functional_hyb_pbe0)
+       !
+       if ( exx_niter < exx_siter ) then
+          exx_tmp = one
+       else
+          exx_tmp = one - exx_alpha
+       end if
+       !
+       call get_xc_energy_hyb_PBE0(density, xc_energy, size, exx_tmp, functional_gga_pbe96 )
+       !
+       !
+    case (functional_hartree_fock)
+       ! **<lat>**
+       ! not optimal but experimental
+       if (exx_niter < exx_siter) then
+          ! for the first call of get_H_matrix using Hartree-Fock method
+          ! to get something not to much stupid ; use pure exchange functional
+          ! in near futur such as Xalpha
+          call get_xc_energy_LSDA_PW92(density, xc_energy, size)
+       else
+          xc_energy    = zero
+       end if
+       !
+       !
+    case default
+       call get_xc_energy_LSDA_PW92(density, xc_energy, size)
+       !
+       !
+    end select
+    return
+  end subroutine get_xc_energy
+  !!***
+
+  !!****f* XC_module/get_xc_energy_LDA_PZ81 *
+  !!
+  !!  NAME
+  !!   get_xc_energy_LDA_PZ81
+  !!  USAGE
+  !!
+  !!  PURPOSE
+  !!   Calculates the exchange-correlation energy
+  !!   on the grid within LDA using the Ceperley-Alder
+  !!   interpolation formula. 
+  !!
+  !!   Note that this is the Perdew-Zunger parameterisation of the
+  !!   Ceperley-Alder results for a homogeneous electron gas, as
+  !!   described in Phys. Rev. B 23, 5048 (1981), with Ceperley-Alder in
+  !!   Phys. Rev. Lett. 45, 566 (1980)
+  !!       Exchange energy: It can be found in:
+  !!                        Phys. Rev. B 45, 13244 (1992)
+  !!                      **See Eq. 26
+  !!       Correlation energy: The correlation functional is PZ-81
+  !!                           Phys. Rev. B 23, 5048 (1981)
+  !!                         **See Appendix C, and specially Table XII,
+  !!                             Eq. C1 for the xc hole (rs),
+  !!                             Eqs. C3 & C4, for rs > 1 and
+  !!                             Eqs. C5 & C6, for rs < 1
   !!  INPUTS
   !!
   !!
   !!  USES
   !!
   !!  AUTHOR
-  !!   A.S. Torralba
+  !!   E.H.Hernandez/DRB
   !!  CREATION DATE
-  !!   11/11/05
+  !!   02/03/95 and 2021/07/22
   !!  MODIFICATION HISTORY
-  !!   17/07/06 rgradient(1,:) used for storage of final result, before transform,
-  !!            instead of direct transform of the sum
-  !!            rgradient(1,:) + rgradient(2,:) + rgradient(3,:)
-  !!          (this was less efficient)
-  !!   15:55, 27/04/2007 drb
-  !!     Changed recip_vector, grad_density to (n,3) for speed
-  !!   2008/11/13 ast
-  !!     Added revPBE and RPBE
-  !!   2011/12/12 L.Tong
-  !!     Removed third, it is now defined in numbers_module
-  !!   2012/04/11 L.Tong
-  !!     Added optional parameters x_epsilon and c_epsilon to output
-  !!     the exchange and correlation parts of xc_epsilon respectively.
-  !!   2017/08/29 jack baker & dave
-  !!     Removed rcellx references (redundant)
   !!  SOURCE
   !!
-  subroutine get_xc_potential_GGA_PBE_obsolete(density, xc_potential, &
-                                               xc_epsilon, xc_energy, &
-                                               size, flavour,         &
-                                               x_epsilon, c_epsilon)
+  subroutine get_xc_energy_LDA_PZ81(density, xc_energy, size)
 
     use datatypes
     use numbers
-    use dimens,        only: grid_point_volume, n_my_grid_points
-    use GenComms,      only: gsum, cq_abort
-    use fft_module,    only: fft3, recip_vector
+    use GenComms,               only: gsum
+    use dimens,                 only: grid_point_volume, n_my_grid_points
+
+    implicit none
+
+    ! Passed variables
+    integer,                    intent(in)  :: size
+    real(double),               intent(out) :: xc_energy
+    real(double), dimension(:), intent(in)  :: density
+
+    ! Local variables
+    integer      :: n
+    real(double) :: denominator, e_correlation, e_exchange, ln_rs, &
+                    numerator, rcp_rs, rho, rs, rs_ln_rs, sq_rs,   &
+                    v_correlation, v_exchange
+    real(double), parameter :: alpha  = -0.45817_double
+    real(double), parameter :: beta_1 =  1.0529_double
+    real(double), parameter :: beta_2 =  0.3334_double
+    real(double), parameter :: gamma  = -0.1423_double
+    real(double), parameter :: p =  0.0311_double
+    real(double), parameter :: q = -0.048_double
+    real(double), parameter :: r =  0.0020_double
+    real(double), parameter :: s = -0.0116_double
+
+    xc_energy = zero
+
+    do n = 1, n_my_grid_points ! loop over grid pts and store potl on each
+       rho = spin_factor * density(n)  ! DRB Added to correct for lack of spin 2018/06/11
+       if (rho > RD_ERR) then ! Find radius of hole
+          rcp_rs = ( four_thirds * pi * rho )**(third)
+       else
+          rcp_rs = zero
+       end if
+       e_exchange = alpha * rcp_rs
+       if (rcp_rs>zero) then
+          rs = one/rcp_rs
+       else
+          rs = zero
+       end if
+       sq_rs = sqrt(rs)
+       if (rs>=one) then
+          denominator = one / (one + beta_1 * sq_rs + beta_2 * rs)
+          numerator   = one + seven_sixths * beta_1 * sq_rs +  &
+               four_thirds * beta_2 * rs
+          e_correlation = gamma * denominator
+       else if ((rs<one).and.(rs>RD_ERR)) then
+          ln_rs    = log(rs)
+          rs_ln_rs = rs * ln_rs
+          e_correlation = p * ln_rs + q  + r * rs_ln_rs + s * rs
+       else
+          e_correlation = zero
+       end if
+       xc_energy       = xc_energy  + (e_exchange + e_correlation) * spin_factor * density(n)  ! DRB Added to correct for lack of spin 2018/06/11
+    end do ! do n_my_grid_points
+    call gsum(xc_energy)
+    ! and 'integrate' the energy over the volume of the grid point
+    xc_energy = xc_energy * grid_point_volume
+
+    return
+  end subroutine get_xc_energy_LDA_PZ81
+  !!***
+
+
+  !!****f* XC_module/get_GTH_xc_energy *
+  !!
+  !!  NAME
+  !!   get_xc_energy
+  !!  USAGE
+  !!
+  !!  PURPOSE
+  !!   Calculates the exchange-correlation energy
+  !!   on the grid within LDA using the Ceperley-Alder
+  !!   interpolation formula. It also calculates the
+  !!   total exchange-correlation energy.
+  !!
+  !!   Note that this is the Goedecker/Teter/Hutter formula which
+  !!   involves only ratios of polynomials, and is rather easy to
+  !!   differentiate.  See PRB 54, 1703 (1996)
+  !!  INPUTS
+  !!
+  !!
+  !!  USES
+  !!
+  !!  AUTHOR
+  !!   D.R.Bowler
+  !!  CREATION DATE
+  !!   14:45, 25/03/2003 and 2021/07/22 14:51 
+  !!  MODIFICATION HISTORY
+  !!  SOURCE
+  !!
+  subroutine get_GTH_xc_energy(density, xc_energy, size)
+
+    use datatypes
+    use numbers
+    use global_module,          only: io_lun
+    use GenComms,               only: cq_abort, gsum
+    use dimens,                 only: grid_point_volume, n_my_grid_points
 
     implicit none
 
     ! Passed variables
     integer,      intent(in)  :: size
-    real(double), intent(in)  :: density(size)
-    real(double), intent(out) :: xc_potential(size), xc_epsilon(size)
     real(double), intent(out) :: xc_energy
-    ! optional
-    integer,intent(in), optional :: flavour
-    real(double), dimension(size), optional, intent(out) :: x_epsilon, c_epsilon
+    real(double), dimension(:), intent(in)  :: density
 
-    !     Local variables
-    integer :: n
-    integer :: selector
-
-    real(double), allocatable, dimension(:)   :: grad_density
-    real(double), allocatable, dimension(:,:) :: grad_density_xyz
-    real(double), allocatable, dimension(:)   :: ex_lda, ec_lda
-    real(double) :: rho, grad_rho, rho1_3, rho1_6, ks, s, s2, t, t2,   &
-                    A, At2, factor0, factor1, factor2, factor3,        &
-                    factor4, denominator0, numerator1, denominator1,   &
-                    num_den1, numerator2, dt2_drho, dA_drho,           &
-                    dnumerator1_drho, ddenominator1_drho,              &
-                    dnumerator1_dt2, dnumerator1_dA,                   &
-                    ddenominator1_dt2, ddenominator1_dA, dfactor2_dt2, &
-                    dfactor2_dnumerator1, dfactor2_ddenominator1,      &
-                    dfactor2_drho, dfactor3_dfactor2, dfactor3_drho
-    real(double) :: xc_energy_lda_total,                               &
-                    e_correlation_lda,                                 &
-                    de_correlation_lda,                                &
-                    e_exchange, e_correlation,                         &
-                    de_exchange, de_correlation,                       &
-                    dde_exchange, dde_correlation
-    real(double) :: df_dgrad_rho
-    real(double) :: kappa, mu_kappa
-    real(double) :: rpbe_exp
-    ! Gradient in reciprocal space
-    complex(double_cplx), allocatable, dimension(:,:) :: rgradient
-
-    !     From Phys. Rev. Lett. 77, 3865 (1996)
-    real(double), parameter :: mu = 0.21951_double
-    real(double), parameter :: beta = 0.066725_double
-    real(double), parameter :: gamma = 0.031091_double
-    real(double), parameter :: kappa_ori = 0.804_double
-
-    !     From Phys. Rev. Lett. 80, 890 (1998)
-    real(double), parameter :: kappa_alt = 1.245_double
-
-    !     Precalculated constants
-    real(double), parameter :: mu_kappa_ori = 0.27302_double     ! mu/kappa_ori
-    real(double), parameter :: mu_kappa_alt = 0.17631_double     ! mu/kappa_alt
-    real(double), parameter :: two_mu = 0.43902_double           ! 2*mu
-    real(double), parameter :: beta_gamma = 2.146119_double      ! beta/gamma
-    real(double), parameter :: beta_X_gamma = 0.002074546_double ! beta*gamma
-    real(double), parameter :: k01 = 0.16162045967_double        ! 1/(2*(3*pi*pi)**(1/3))
-    real(double), parameter :: k02 = -0.16212105381_double       ! -3*mu*((4*pi/3)**(1/3))/(2*pi*alpha)
-                                                                 ! =mu*k00*k01(LDA_PW92)=mu*k04
-    real(double), parameter :: k03 = 1.98468639_double           ! ((4/pi)*(3*pi*pi)**(1/3))**(1/2)
-    real(double), parameter :: k04 = -0.738558852965_double      ! -3*((4*pi/3)**(1/3))/(2*pi*alpha) = k00*k01 in LDA_PW92
-    real(double), parameter :: k05 = 0.05240415_double           ! -2*k01*k02
-    real(double), parameter :: k06 = -0.593801317784_double      ! k04*kappa_ori
-    real(double), parameter :: k07 = -0.984745137287_double      ! 4*k04/3
-    real(double), parameter :: seven_thirds = 2.333333333_double ! 7/3
-
-    integer :: stat
-    !      Selector options
-    integer, parameter :: fx_original    = 1                     ! Used in PBE and revPBE
-    integer, parameter :: fx_alternative = 2                     ! Used in RPBE
-
-    ! Choose between PBE or revPBE parameters
-    if(PRESENT(flavour)) then
-      if(flavour==functional_gga_pbe96_rev98) then
-        kappa=kappa_alt
-        mu_kappa=mu_kappa_alt
-      else
-        kappa=kappa_ori
-        mu_kappa=mu_kappa_ori
-      end if
-    else
-      kappa=kappa_ori
-      mu_kappa=mu_kappa_ori
-    end if
-
-    if (present(x_epsilon)) then
-       allocate(ex_lda(size), STAT=stat)
-       if (stat /= 0) &
-            call cq_abort("Error allocating ex_lda for PBE functional: ", stat)
-    end if
-
-    if (present(c_epsilon)) then
-       allocate(ec_lda(size), STAT=stat)
-       if (stat /= 0) &
-            call cq_abort("Error allocating ec_lda for PBE functional ", stat)
-    end if
-
-    allocate(grad_density(size), grad_density_xyz(size,3),&
-             rgradient(size,3),STAT = stat)
-    !initialisation  2010.Oct.30 TM
-    grad_density(:) = zero
-    grad_density_xyz(:,:) = zero
-    rgradient(:,:) = zero
-    xc_epsilon(:) = zero
-    xc_potential(:) = zero
-    if (present(x_epsilon)) then
-       x_epsilon = zero
-       ex_lda = zero
-    end if
-    if (present(c_epsilon)) then
-       c_epsilon = zero
-       ec_lda = zero
-    end if
-    if (stat /= 0) &
-         call cq_abort("Error allocating arrays for PBE functional: ", stat)
-
-    ! Choose functional form
-    if (present(flavour)) then
-       if (flavour == functional_gga_pbe96_r99) then
-          selector = fx_alternative
-       else
-          selector = fx_original
-       end if
-    else
-       selector = fx_original
-    end if
-
-    ! Build the gradient of the density
-    call build_gradient(density, grad_density_xyz, size)
-
-    grad_density(:) = sqrt(grad_density_xyz(:,1)**2 + &
-                           grad_density_xyz(:,2)**2 + &
-                           grad_density_xyz(:,3)**2)
-
-    ! Get the LDA part of the functional
-    if (present(x_epsilon) .and. present(c_epsilon)) then
-       call get_xc_potential_LDA_PW92(density, xc_potential, xc_epsilon, &
-                                      xc_energy_lda_total, size,         &
-                                      x_epsilon=ex_lda,                  &
-                                      c_epsilon=ec_lda)
-    else if (present(x_epsilon)) then
-       call get_xc_potential_LDA_PW92(density, xc_potential, xc_epsilon, &
-                                      xc_energy_lda_total, size,         &
-                                      x_epsilon=ex_lda)
-    else if (present(c_epsilon)) then
-       call get_xc_potential_LDA_PW92(density, xc_potential, xc_epsilon, &
-                                      xc_energy_lda_total, size,         &
-                                      c_epsilon=ec_lda)
-    else
-       call get_xc_potential_LDA_PW92(density, xc_potential, xc_epsilon, &
-                                      xc_energy_lda_total, size)
-    end if
+    ! Local variables
+    integer n
+    real(double) :: denominator, e_correlation, e_exchange, ln_rs,    &
+                    numerator, rcp_rs, rho, rs, rs_ln_rs, sq_rs,      &
+                    v_correlation, v_exchange, drs_dRho, t1, t2, dt1, &
+                    dt2
+    real(double), parameter :: a0=0.4581652932831429_double
+    real(double), parameter :: a1=2.217058676663745_double
+    real(double), parameter :: a2=0.7405551735357053_double
+    real(double), parameter :: a3=0.01968227878617998_double
+    real(double), parameter :: b1=1.000000000000000_double
+    real(double), parameter :: b2=4.504130959426697_double
+    real(double), parameter :: b3=1.110667363742916_double
+    real(double), parameter :: b4=0.02359291751427506_double
 
     xc_energy = zero
     do n = 1, n_my_grid_points ! loop over grid pts and store potl on each
-       rho = density(n)
-       grad_rho = grad_density(n)
-
-       !!!!!!   XC GGA ENERGY
-
-       ! Exchange
-
-       if (rho > RD_ERR) then
-          rho1_3 = rho ** third
-          rho1_6 = sqrt (rho1_3)
-          s = k01 * grad_rho / (rho ** four_thirds)
-          s2 = s * s
-          if(selector == fx_alternative) then           ! RPBE
-            rpbe_exp = exp(-mu_kappa * s2)
-            e_exchange = k06*rho1_3*(1.0_double-rpbe_exp)
-          else                                          ! PBE, revPBE
-            denominator0 = 1.0 / (1.0 + mu_kappa * s2)
-            factor0 = k02 * rho1_3
-            factor1 = s2 * denominator0
-            ! NOTE: This doesn't look like in Phys. Rev. Lett. 77:18,
-            !       3865 (1996) because the 1 in Fx, has been
-            !       multiplied by Ex-LDA and is implicit in
-            !       xc_energy_lda(n), in the total energy below
-            e_exchange = factor0 * factor1
-          end if
+       rho = spin_factor * density(n)  ! DRB Added to correct for lack of spin 2018/06/11
+       if (rho > RD_ERR) then ! Find radius of hole
+          rcp_rs = ( four*third * pi * rho )**(third)
+          rs     = one/rcp_rs
        else
-          e_exchange = zero
+          rcp_rs = zero
+          rs     = zero
        end if
-
-       if (present(x_epsilon)) x_epsilon(n) = e_exchange + ex_lda(n)
-
-       ! Correlation
-
-       if (rho > RD_ERR) then
-          e_correlation_lda = xc_epsilon(n) - k04 * rho1_3
-
-          ! t=grad_rho/(2*rho*ks); ks=sqrt(4*kf/pi); kf=(3*pi*pi*rho)**(1/3); s=grad_rho/(2*rho*kf)
-          ks = k03 * rho1_6
-          t = grad_rho / ( 2 * ks * rho )
-          t2 = t * t
-
-          A = exp(-e_correlation_lda / gamma) - 1.0
-          if (A > RD_ERR) then
-             A = beta_gamma / A
-          else
-             A = beta_gamma * BIG
-          end if
-
-          At2 = A * t2
-          numerator1 = 1.0 + At2
-          denominator1 = 1.0 + At2 + At2 * At2
-          num_den1 = numerator1 / denominator1
-
-          factor2 = t2 * num_den1
-          factor3 = gamma * log(one + beta_gamma * factor2)
-
-          e_correlation = factor3;  !gamma * log( 1.0 + beta_gamma * t2 * num_den1 )
-       else
-          e_correlation = zero
+       if (rs > zero) then
+          drs_dRho = -rs / (3.0 * rho)
+          t1  = a0 + rs*(a1 + rs * (a2 + rs * a3))
+          t2  = rs * (b1 + rs * (b2 + rs * (b3 + rs * b4)))
+          dt1 = a1 + rs * (2.0 * a2 + rs * 3.0 * a3)
+          dt2 = b1 + rs * (2.0 * b2 + rs * (3.0 * b3 + rs * 4.0 * b4))
+          xc_energy = xc_energy - (t1/t2)*rho
        end if
-
-       if (present(c_epsilon)) c_epsilon(n) = e_correlation + ec_lda(n)
-
-       !*ast* TEST-POINT 1
-       ! Both exchange and correlation
-       xc_energy = xc_energy + (xc_epsilon(n) + e_exchange + e_correlation)*rho
-       ! Only LDA part
-       !xc_energy = xc_energy + (xc_epsilon(n))*rho
-       ! LDA + exchange
-       !xc_energy = xc_energy + (xc_epsilon(n) + e_exchange)*rho
-       ! Only exchange
-       !xc_energy = xc_energy + (e_exchange)*rho
-       ! LDA + correlation
-       !xc_energy = xc_energy + (xc_epsilon(n) + e_correlation)*rho
-       ! Only correlation
-       !xc_energy = xc_energy + (e_correlation)*rho
-
-       !!!!!!   POTENTIAL
-
-       !!!   Terms due to df/drho
-
-       ! Exchange
-
-       if (rho > RD_ERR) then
-          if(selector == fx_alternative) then           ! RPBE
-            de_exchange = k07 * rho1_3 * (kappa - (two_mu * s2 + kappa) * rpbe_exp)
-          else                                          ! PBE, revPBE
-            de_exchange = four_thirds * factor0 * factor1 * ( 1 - 2* denominator0 )
-          end if
-       else
-          de_exchange = zero
-       end if
-
-       ! Correlation
-
-       if (rho > RD_ERR) then
-          de_correlation_lda = ( xc_potential(n) &
-                               - four_thirds * k04 * rho1_3 &
-                               - e_correlation_lda ) / rho
-
-          dt2_drho = -seven_thirds * t2 / rho
-          dA_drho  = A * A * exp(-e_correlation_lda / gamma ) * de_correlation_lda / beta
-          dnumerator1_dt2   = A
-          dnumerator1_dA    = t2
-          factor4 = 1.0 + 2 * At2
-          ddenominator1_dt2 = A * factor4
-          ddenominator1_dA  = t2 * factor4
-          dnumerator1_drho   = dnumerator1_dt2 * dt2_drho &
-                             + dnumerator1_dA * dA_drho
-          ddenominator1_drho = ddenominator1_dt2 * dt2_drho &
-                             + ddenominator1_dA * dA_drho
-          dfactor2_dt2 = num_den1
-          dfactor2_dnumerator1   = t2 / denominator1
-          dfactor2_ddenominator1 = -factor2 / denominator1
-          dfactor2_drho = dfactor2_dt2 * dt2_drho &
-                        + dfactor2_dnumerator1 * dnumerator1_drho &
-                        + dfactor2_ddenominator1 * ddenominator1_drho
-          dfactor3_dfactor2 = beta / ( 1.0 + beta_gamma * factor2 )
-          dfactor3_drho = dfactor3_dfactor2 * dfactor2_drho
-          de_correlation = factor3 + rho * dfactor3_drho
-       else
-          de_correlation = zero
-       end if
-
-       !*ast* TEST-POINT 2
-       xc_potential(n) = xc_potential(n) + de_exchange + de_correlation
-       ! Only LDA part
-       !xc_potential(n) = xc_potential(n)
-       ! LDA + exchange
-       !xc_potential(n) = xc_potential(n) + de_exchange
-       ! Only exchange
-       !xc_potential(n) = de_exchange
-       ! LDA + correlation
-       !xc_potential(n) = xc_potential(n) + de_correlation
-       ! Only correlation
-       !xc_potential(n) = de_correlation
-
-       !!!   Terms due to df/d|grad_rho|
-
-       ! Exchange
-
-       if (rho > RD_ERR) then
-          if(selector == fx_alternative) then           ! RPBE
-             dde_exchange = -k05 * s * rpbe_exp
-          else                                          ! PBE, revPBE
-             dde_exchange = -k05 * s * denominator0 * denominator0!factor1 * denominator0
-          end if
-       else
-          dde_exchange = zero
-       end if
-
-       ! Correlation
-
-       if (rho > RD_ERR) then
-          numerator2 = beta_X_gamma * t * ( 1.0 + 2.0 * At2 ) &
-                     / (( gamma * denominator1 + beta * t2 * numerator1 ) * denominator1)
-          dde_correlation = numerator2 / ks;
-       else
-          dde_correlation = zero
-       end if
-
-       ! Normalisation (modulus of gradient)
-
-       !*ast* TEST-POINT 3
-       if(abs(grad_density(n)) > RD_ERR) then  !DEBUG
-       df_dgrad_rho = (dde_exchange + dde_correlation) / grad_density(n)
-       else                 !DEBUG
-       df_dgrad_rho = zero   !DEBUG
-       endif                !DEBUG
-       ! Only LDA part
-       !df_dgrad_rho = 0.0
-       ! LDA + exchange
-       !df_dgrad_rho = dde_exchange / grad_density(n)
-       ! Only exchange
-       !df_dgrad_rho = dde_exchange / grad_density(n)
-       ! LDA + correlation
-       !df_dgrad_rho = dde_correlation / grad_density(n)
-       ! Only correlation
-       !df_dgrad_rho = dde_correlation / grad_density(n)
-
-
-       ! Gradient times derivative of energy
-
-       grad_density_xyz(n,1) = grad_density_xyz(n,1)*df_dgrad_rho
-       grad_density_xyz(n,2) = grad_density_xyz(n,2)*df_dgrad_rho
-       grad_density_xyz(n,3) = grad_density_xyz(n,3)*df_dgrad_rho
-
-       !xc_epsilon  !2010.Oct.30 TM
-       xc_epsilon(n) = xc_epsilon(n) + e_exchange + e_correlation
-       !*ast* TEST-POINT 4
-       !TM delta_E_xc = delta_E_xc + (xc_epsilon(n) + e_exchange + e_correlation)*rho
-       ! Only LDA part
-       !delta_E_xc = delta_E_xc + (xc_epsilon(n))*rho
-       ! LDA + exchange
-       !delta_E_xc = delta_E_xc + (xc_epsilon(n) + e_exchange)*rho
-       ! Only exchange
-       !delta_E_xc = delta_E_xc + (e_exchange)*rho
-       ! LDA + correlation
-       !delta_E_xc = delta_E_xc + (xc_epsilon(n) + e_correlation)*rho
-       ! Only correlation
-       !delta_E_xc = delta_E_xc + (e_correlation)*rho
-
     end do ! do n_my_grid_points
-
-
-    !!!   Final steps of the energy calculation
-
-    ! Add the energies and 'integrate' over the volume of the grid points
-
     call gsum(xc_energy)
+    ! and 'integrate' the energy over the volume of the grid point
     xc_energy = xc_energy * grid_point_volume
-
-    ! Fourier transform the gradient, component by component
-
-    call fft3(grad_density_xyz(:,1), rgradient(:,1), size, -1 )
-    call fft3(grad_density_xyz(:,2), rgradient(:,2), size, -1 )
-    call fft3(grad_density_xyz(:,3), rgradient(:,3), size, -1 )
-
-    !!!   Get the second term of the potential by taking derivatives
-
-    ! First, get the scalar product of the (normalised) gradient and the wave vector (times i)
-
-    rgradient(:,1) = -rgradient(:,1)*minus_i*recip_vector(:,1)
-    rgradient(:,1) = rgradient(:,1) - rgradient(:,2)*minus_i*recip_vector(:,2)
-    rgradient(:,1) = rgradient(:,1) - rgradient(:,3)*minus_i*recip_vector(:,3)
-
-    ! Add terms of the scalar product and then Fourier transform back the resultant vector
-    ! NOTE: Store the result in the modulus of the gradient (not needed anymore) to save memory
-
-    call fft3( grad_density, rgradient(:,1), size, 1 )
-
-    ! Finally, get the potential
-    ! NOTE that here grad_density is NOT the modulus of the gradient,
-    !      but a term of the potential (see Fourier transform above)
-
-    do n=1,n_my_grid_points
-        xc_potential(n) = xc_potential(n) - grad_density(n)
-    end do
-
-    ! I changed the order of deallocation, because I was told that deallocation
-    ! of the latest allocated array should be done first.
-    ! (though I am not sure whether it is true or not)   2010.Oct.30 TM
-
-    if(allocated(rgradient)) then
-       deallocate(rgradient,STAT=stat)
-       if(stat/=0) call cq_abort("Error deallocating rgradient",stat)
-    end if
-    if(allocated(grad_density_xyz)) then
-       deallocate(grad_density_xyz,STAT=stat)
-       if(stat/=0) call cq_abort("Error deallocating grad_density_xyz",stat)
-    end if
-    if(allocated(grad_density)) then
-       deallocate(grad_density,STAT=stat)
-       if(stat/=0) call cq_abort("Error deallocating grad_density",stat)
-    end if
-    if (allocated(ex_lda)) then
-       deallocate(ex_lda,STAT=stat)
-       if (stat /= 0) call cq_abort("Error deallocating ex_lda", stat)
-    end if
-    if (allocated(ec_lda)) then
-       deallocate(ec_lda,STAT=stat)
-       if (stat /= 0) call cq_abort("Error deallocating ec_lda", stat)
-    end if
-
     return
-  end subroutine get_xc_potential_GGA_PBE_obsolete
+  end subroutine get_GTH_xc_energy
   !!***
 
+  !!****f* XC_module/get_xc_energy_LSDA_PW92 *
+  !!
+  !!  NAME
+  !!   get_xc_energy_LSDA_PW92
+  !!  USAGE
+  !!
+  !!  PURPOSE
+  !!   Calculates the spin polarized exchange-correlation
+  !!   energy on the grid within LDA using the Ceperley-Alder
+  !!   interpolation formula. It also calculates the total
+  !!   exchange-correlation energy.
+  !!
+  !!   Note that this is the Perdew-Wang parameterisation of the
+  !!   Ceperley-Alder results for a homogeneous electron gas, as
+  !!   described in Phys. Rev. B 45, 13244 (1992), with Ceperley-Alder
+  !!   in Phys. Rev. Lett. 45, 566 (1980) INPUTS
+  !!
+  !!  USES
+  !!
+  !!  AUTHOR
+  !!   L. Tong and DRB
+  !!  CREATION DATE
+  !!   22/03/2011 and 2021/07/22 14:52
+  !!  MODIFICATION HISTORY
+  !!  SOURCE
+  !!
+  subroutine get_xc_energy_LSDA_PW92(density, xc_energy_total, size)
+
+    use datatypes
+    use numbers
+    use GenComms,               only: cq_abort, gsum
+    use dimens,                 only: grid_point_volume, n_my_grid_points
+    use global_module,          only: nspin
+
+    implicit none
+
+    ! Passed variables
+    ! size of the real space grid
+    integer,                      intent(in)  :: size
+    real(double),                 intent(out) :: xc_energy_total
+    real(double), dimension(:,:), intent(in)  :: density
+
+    ! Local variables
+    integer      :: rr, spin
+    real(double) :: eps_x, eps_c, rho_tot_r
+    real(double), dimension(nspin) :: rho_r, Vx, Vc
+
+    ! initialisation
+    xc_energy_total = zero
+
+    ! loop over grid points on each node
+    do rr = 1, n_my_grid_points
+       rho_r(1:nspin) = density(rr,1:nspin)
+       rho_tot_r      = rho_r(1) + rho_r(nspin)
+       call Vxc_of_r_LSDA_PW92(nspin, rho_r, eps_x=eps_x, eps_c=eps_c,&
+                               Vx=Vx, Vc=Vc)
+
+       xc_energy_total = xc_energy_total + (eps_x + eps_c)  * rho_tot_r
+    end do
+    call gsum(xc_energy_total)
+    xc_energy_total = xc_energy_total * grid_point_volume
+    return
+  end subroutine get_xc_energy_LSDA_PW92
+  !!***
+
+  !!****f* XC_module/get_xc_energy_GGA_PBE
+  !! PURPOSE
+  !!   Calculates the exchange-correlation energy
+  !!   on the grid within GGA using three flavours of
+  !!   Perdew-Burke-Ernzerhof. It also calculates the
+  !!   total exchange-correlation energy.
+  !!
+  !!   flavour not defined
+  !!     use original PBE, PRL 77, 3865 (1996)
+  !!   flavour = functional_gga_pbe96_rev98:
+  !!     use revPBE, PRL 80, 890 (1998)
+  !!   flavour = functional_gga_pbe96_r99:
+  !!     use RPBE, PRB 59, 7413 (1999)
+  !!
+  !! USAGE
+  !!   call get_xc_energy_GGA_PBE(density, xc_potential,      &
+  !!                                 xc_epsilon, xc_energy, size,&
+  !!                                 flavour)
+  !! INPUTS
+  !!   integer      size                : size of the real space grid
+  !!   integer      flavour             : flavour of PBE functional (optional)
+  !!   real(double) density(size,nspin) : spin dependent density
+  !! OUTPUT
+  !!   real(double) xc_energy                : total xc-energy (sum over spin)
+  !!   real(double) xc_epsilon(size)         : xc-energy density
+  !!   real(double) xc_potential(size,nspin) : xc-potnetial
+  !! AUTHOR
+  !!   L.Tong and DRB
+  !! CREATION DATE 
+  !!   2012/04/27 and 2021/07/22 14:54 dave
+  !! MODIFICATION HISTORY
+  !! SOURCE
+  !!
+  subroutine get_xc_energy_GGA_PBE(density, xc_energy, grid_size, flavour)
+
+    use datatypes
+    use numbers
+    use global_module, only: nspin, flag_stress, flag_full_stress
+    use dimens,        only: grid_point_volume, n_my_grid_points
+    use GenComms,      only: gsum, cq_abort
+    use fft_module,    only: fft3, recip_vector
+    use memory_module, only: reg_alloc_mem, reg_dealloc_mem, type_dbl
+
+    implicit none
+
+    ! passed variables
+    integer,                      intent(in)  :: grid_size
+    real(double), dimension(:,:), intent(in)  :: density
+    real(double),                 intent(out) :: xc_energy
+    integer,      optional,       intent(in)  :: flavour
+
+    ! local variables
+    integer      :: PBE_type
+    integer      :: rr, spin, stat, dir1, dir2
+    real(double) :: eps_x, eps_c, rho_tot_r
+    real(double),         dimension(nspin)        :: rho_r
+    real(double),         dimension(3,nspin)      :: grho_r
+    real(double),         dimension(:,:,:), allocatable :: grad_density
+
+    allocate(grad_density(grid_size,3,nspin), STAT=stat)
+    if (stat /= 0) call cq_abort("get_xc_potential_GGA_PBE: Error alloc mem: ", grid_size)
+    call reg_alloc_mem(area_ops, grid_size*3*nspin, type_dbl)
+
+    if (present(flavour)) then
+       PBE_type = flavour
+    else
+       PBE_type = functional_gga_pbe96
+    end if
+
+    ! initialisation
+    grad_density = zero
+    xc_energy    = zero
+
+    ! Build the gradient of the density
+    do spin = 1, nspin
+       call build_gradient(density(:,spin), grad_density(:,:,spin), grid_size)
+    end do
+
+    do rr = 1, n_my_grid_points
+       rho_tot_r = density(rr,1) + density(rr,nspin)
+       do spin = 1, nspin
+          rho_r(spin)      = density(rr,spin)
+          grho_r(1:3,spin) = grad_density(rr,1:3,spin)
+       end do
+       call eps_xc_of_r_GGA_PBE(nspin, PBE_type, rho_r, grho_r, &
+                                eps_x=eps_x, eps_c=eps_c)
+       xc_energy      = xc_energy + rho_tot_r * (eps_x + eps_c)
+    end do ! rr
+    call gsum(xc_energy)
+    xc_energy = xc_energy * grid_point_volume
+    deallocate(grad_density, STAT=stat)
+    if (stat /= 0) call cq_abort("get_xc_potential_GGA_PBE: Error dealloc mem")
+    call reg_dealloc_mem(area_ops, grid_size*3*nspin, type_dbl)
+
+  end subroutine get_xc_energy_GGA_PBE
+  !!*****
+
+
+  !!****f* XC_module/get_xc_energy_hyb_PBE0
+  !! PURPOSE
+  !!
+  !!   Work routine based on get_xc_energy_GGA_PBE.
+  !!   It will be recoded in near futur to handle any hybrid functional.
+  !!   For now just handle one coefficient as in PBE0.
+  !! USAGE
+  !!
+  !! INPUTS
+  !!
+  !!   integer      size                : size of the real space grid
+  !!   integer      flavour             : flavour of PBE functional (optional)
+  !!   real(double) density(size,nspin) : spin dependent density
+  !! OUTPUT
+  !!   real(double) xc_energy                : total xc-energy (sum over spin)
+  !!
+  !! AUTHOR
+  !!   L.Tong/L.Truflandier/DRB
+  !! CREATION DATE
+  !!   2014/09/24 and 2021/07/22 15:00 dave
+  !! MODIFICATION HISTORY
+  !! SOURCE
+  !!
+  subroutine get_xc_energy_hyb_PBE0(density, xc_energy, grid_size, exx_a, flavour )
+    use datatypes
+    use numbers
+    use global_module, only: nspin, flag_full_stress, flag_stress
+    use dimens,        only: grid_point_volume, n_my_grid_points
+    use GenComms,      only: gsum, cq_abort
+    use fft_module,    only: fft3, recip_vector
+    use memory_module, only: reg_alloc_mem, reg_dealloc_mem, type_dbl
+
+    implicit none
+
+    ! passed variables
+    integer,                      intent(in)  :: grid_size
+    real(double), dimension(:,:), intent(in)  :: density
+    real(double),                 intent(out) :: xc_energy
+    integer,      optional,       intent(in)  :: flavour
+    real(double),                 intent(in)  :: exx_a
+
+    ! local variables
+    integer      :: PBE_type
+    integer      :: rr, spin, stat, dir1, dir2
+    real(double) :: eps_x, eps_c, rho_tot_r
+    real(double),         dimension(nspin)        :: rho_r
+    real(double),         dimension(3,nspin)      :: grho_r
+    real(double),         dimension(:,:,:), allocatable :: grad_density
+
+    allocate(grad_density(grid_size,3,nspin), STAT=stat)
+    if (stat /= 0) call cq_abort("get_xc_potential_GGA_PBE: Error alloc mem: ", grid_size)
+    call reg_alloc_mem(area_ops, grid_size*3*nspin, type_dbl)
+
+    if (present(flavour)) then
+       PBE_type = flavour
+    else
+       PBE_type = functional_gga_pbe96
+    end if
+
+    ! setup exx_a
+
+    ! Initialisation
+    grad_density = zero
+    xc_energy    = zero
+
+    ! Build the gradient of the density
+    do spin = 1, nspin
+       call build_gradient(density(:,spin), grad_density(:,:,spin), grid_size)
+    end do
+
+    do rr = 1, n_my_grid_points
+       rho_tot_r = density(rr,1) + density(rr,nspin)
+       do spin = 1, nspin
+          rho_r(spin)      = density(rr,spin)
+          grho_r(1:3,spin) = grad_density(rr,1:3,spin)
+       end do
+       call eps_xc_of_r_GGA_PBE(nspin, PBE_type, rho_r, grho_r, &
+                                eps_x    =eps_x, &
+                                eps_c    =eps_c)
+       xc_energy      = xc_energy + rho_tot_r * (exx_a * eps_x + eps_c)
+    end do ! rr
+    call gsum(xc_energy)
+    xc_energy = xc_energy * grid_point_volume
+    deallocate(grad_density, STAT=stat)
+    if (stat /= 0) call cq_abort("get_xc_potential_GGA_PBE: Error dealloc mem")
+    call reg_dealloc_mem(area_ops, grid_size*3*nspin, type_dbl)
+
+    return
+  end subroutine get_xc_energy_hyb_PBE0
+  !!*****
 
   !!****f* XC_module/build_gradient *
   !!

--- a/src/XC_LibXC_v4_module.f90
+++ b/src/XC_LibXC_v4_module.f90
@@ -22,6 +22,8 @@
 !!    Added spin_factor in module use statements
 !!   2019/04/09 zamaan
 !!    Off-diagonal elements of stress tensor added
+!!   2021/07/22 14:26 dave
+!!    Added get_xc_energy routine (and associated)
 !! SOURCE
 !!
 module XC
@@ -45,7 +47,7 @@ module XC
   logical, public :: flag_different_functional
 
   ! Public methods
-  public :: get_xc_potential, get_dxc_potential, init_xc
+  public :: get_xc_potential, get_dxc_potential, init_xc, get_xc_energy
 
   ! LibXC variables
   integer :: n_xc_terms
@@ -1032,6 +1034,137 @@ contains
   end subroutine get_libxc_dpotential
   !!***
 
+  !!****f* XC_module/get_libxc_energy *
+  !!
+  !!  NAME
+  !!   get_libxc_energy
+  !!  USAGE
+  !!
+  !!  PURPOSE
+  !!   Calculates the exchange-correlation energy
+  !!   on the grid using LibXC
+  !!  INPUTS
+  !!
+  !!  USES
+  !!
+  !!  AUTHOR
+  !!   D. R. Bowler
+  !!  CREATION DATE
+  !!   2021/07/22
+  !!  MODIFICATION HISTORY
+  !!  SOURCE
+  !!
+  subroutine get_libxc_energy(density, xc_energy, size)
+
+    use datatypes
+    use numbers
+    use GenComms,      only: gsum
+    use GenBlas,       only: dot
+    use dimens,        only: grid_point_volume, n_my_grid_points
+    use global_module, only : nspin, io_lun, flag_full_stress, flag_stress
+    use fft_module,    only: fft3, recip_vector
+
+    implicit none
+
+    ! Passed variables
+    integer,                      intent(in)  :: size
+    real(double),                 intent(out) :: xc_energy
+    real(double), dimension(:,:), intent(in)  :: density
+
+    ! local variables
+    real(double), dimension(:), allocatable :: sigma, eps ! Temporary variables
+    real(double), dimension(:), allocatable :: alt_dens
+    real(double), dimension(:,:,:), allocatable :: grad_density
+    real(double) :: rho_tot
+    integer :: stat, i, spin, nxc, j
+
+    ! Storage space for individual components
+    allocate(eps(n_my_grid_points),alt_dens(n_my_grid_points*nspin))
+    ! For GGA, create sigma (\nabla n dot \nabla n) from gradient
+    if(flag_is_GGA) then
+       if(nspin>1) then
+          allocate(sigma(n_my_grid_points*3))
+       else
+          allocate(sigma(n_my_grid_points))
+       endif
+       ! If GGA, we need to find and adapt gradient
+       allocate(grad_density(size,3,nspin),STAT=stat)
+       sigma = zero
+       grad_density = zero
+       do spin = 1, nspin
+          call build_gradient(density(:,spin), grad_density(:,:,spin), size)
+       end do
+       ! Build modulus - NB LibXC uses spin, point for density !
+       if(nspin>1) then
+          ! This is ugly, but there's not really a better way
+          do i=1,n_my_grid_points
+             ! \nabla n_alpha dot \nabla n_alpha
+             sigma(1+(i-1)*3) = &
+               grad_density(i,1,1)*grad_density(i,1,1) + &
+               grad_density(i,2,1)*grad_density(i,2,1) + &
+               grad_density(i,3,1)*grad_density(i,3,1)
+             ! \nabla n_alpha dot \nabla n_beta
+             sigma(2+(i-1)*3) = &
+               grad_density(i,1,1)*grad_density(i,1,2) + &
+               grad_density(i,2,1)*grad_density(i,2,2) + &
+               grad_density(i,3,1)*grad_density(i,3,2)
+             ! \nabla n_beta dot \nabla n_beta
+             sigma(3+(i-1)*3) = &
+               grad_density(i,1,2)*grad_density(i,1,2) + &
+               grad_density(i,2,2)*grad_density(i,2,2) + &
+               grad_density(i,3,2)*grad_density(i,3,2)
+          end do
+       else
+          sigma(1:n_my_grid_points) = &
+               grad_density(1:n_my_grid_points,1,1)*grad_density(1:n_my_grid_points,1,1) + &
+               grad_density(1:n_my_grid_points,2,1)*grad_density(1:n_my_grid_points,2,1) + &
+               grad_density(1:n_my_grid_points,3,1)*grad_density(1:n_my_grid_points,3,1)
+       end if
+    end if
+    ! If we have spin, re-order density to have spin index first
+    ! Otherwise scale
+    if(nspin>1) then
+       do i = 1, n_my_grid_points
+          do spin=1,nspin
+             alt_dens(spin + (i-1)*nspin) = density(i,spin)
+          end do
+       end do
+    else
+       ! Scaling for spin; sigma needs four because it is nabla n .dot. nabla n
+       alt_dens(1:n_my_grid_points) = two*density(1:n_my_grid_points,1)
+       if(flag_is_GGA) then
+          sigma(:) = four*sigma(:)
+          grad_density(:,:,1) = two*grad_density(:,:,1)
+       end if
+    end if
+    ! Create XC energy
+    xc_energy = zero
+    do nxc = 1,n_xc_terms
+       eps = zero
+       select case( i_xc_family(nxc) )
+       case(XC_FAMILY_LDA)
+          call xc_f90_lda_exc( xc_func(nxc), n_my_grid_points, alt_dens(1), eps(1) )
+       case(XC_FAMILY_GGA)
+          call xc_f90_gga_exc( xc_func(nxc), n_my_grid_points, alt_dens(1), sigma(1), eps(1) )
+       end select
+       do i=1,n_my_grid_points
+          rho_tot = density(i,1) + density(i,nspin)
+          xc_energy = xc_energy + eps(i)*rho_tot
+       end do
+    end do ! nxc = n_xc_terms
+    ! Sum to get energy
+    call gsum(xc_energy)
+    ! and 'integrate' the energy over the volume of the grid point
+    xc_energy = xc_energy * grid_point_volume
+
+    deallocate(eps,alt_dens)
+    if(flag_is_GGA)then
+       deallocate(grad_density,sigma)
+    end if
+    return
+  end subroutine get_libxc_energy
+  !!***
+
   ! **********************************
   ! Conquest XC routines go below here
   ! **********************************
@@ -1292,175 +1425,7 @@ contains
   end subroutine get_GTH_xc_potential
   !!***
 
-
-  !!****f* XC_module/get_xc_potential_LDA_PW92 (Obsolete)*
-  !!
-  !!  NAME
-  !!   get_xc_potential_LDA_PW92 (Obsolete)
-  !!  USAGE
-  !!
-  !!  PURPOSE
-  !!   Calculates the exchange-correlation potential on the grid within
-  !!   LDA using the Ceperley-Alder interpolation formula. It also
-  !!   calculates the total exchange-correlation energy.
-  !!
-  !!   Note that this is the Perdew-Wang parameterisation of the
-  !!   Ceperley-Alder results for a homogeneous electron gas, as
-  !!   described in Phys. Rev. B 45, 13244 (1992), with Ceperley-Alder
-  !!   in Phys. Rev. Lett. 45, 566 (1980)
-  !!  INPUTS
-  !!
-  !!  USES
-  !!
-  !!  AUTHOR
-  !!   A.S. Torralba
-  !!  CREATION DATE
-  !!   01/11/05
-  !!  MODIFICATION HISTORY
-  !!   2008/03/03 18:32 dave
-  !!    Removed dsqrt
-  !!   2011/03/22 L.Tong
-  !!    Removed local definition of third, it is now defined in numbers
-  !!    module Changed 1 to one in the log() functions
-  !!   2012/04/03 L.Tong
-  !!   - Added optional variables x_epsilon and c_epsilon so that if
-  !!     present they will store the output for the exchange and
-  !!     correlation parts of xc_epsilon respectively
-  !!   2012/04/25 L.Tong
-  !!   *** THIS SUBROUTINE IS NOW OBSOLETE, USE THE LSDA VERSION ***
-  !!  SOURCE
-  !!
-  subroutine get_xc_potential_LDA_PW92(density, xc_potential,       &
-                                       xc_epsilon, xc_energy_total, &
-                                       size, x_epsilon, c_epsilon)
-
-    use datatypes
-    use numbers
-    use GenComms, only: gsum
-    use dimens,   only: grid_point_volume, n_my_grid_points
-
-    implicit none
-
-    ! Passed variables
-    integer,                    intent(in)  :: size
-    real(double),               intent(out) :: xc_energy_total
-    real(double), dimension(:), intent(in)  :: density
-    real(double), dimension(:), intent(out) :: xc_epsilon, xc_potential
-    ! optional
-    real(double), dimension(:), intent(out), optional :: x_epsilon, c_epsilon
-
-    ! Local variables
-    integer      :: n
-    real(double) :: prefactor, postfactor, denominator, &
-                    e_correlation, e_exchange,          &
-                    rcp_rs, rho, rs, sq_rs,             &
-                    v_correlation, v_exchange,          &
-                    delta_prefactor, delta_postfactor
-
-
-    ! From Table I, Phys. Rev. B 45, 13244 (1992), for reference
-    real(double), parameter :: alpha  = 1.0421234_double
-    real(double), parameter :: alpha1 = 0.21370_double
-    real(double), parameter :: beta1  = 7.5957_double
-    real(double), parameter :: beta2  = 3.5876_double
-    real(double), parameter :: beta3  = 1.6382_double
-    real(double), parameter :: beta4  = 0.49294_double
-    real(double), parameter :: A      = 0.031091_double
-
-    ! Precalculated constants
-    real(double), parameter :: k00 = 1.611991954_double     ! (4*pi/3)**(1/3)
-    real(double), parameter :: k01 = -0.458165347_double    ! -3/(2*pi*alpha)
-    real(double), parameter :: k02 = -0.062182_double       ! -2*A
-    real(double), parameter :: k03 = -0.0132882934_double   ! -2*A*alpha1
-    real(double), parameter :: k04 = 0.4723158174_double    ! 2*A*beta1
-    real(double), parameter :: k05 = 0.2230841432_double    ! 2*A*beta2
-    real(double), parameter :: k06 = 0.1018665524_double    ! 2*A*beta3
-    real(double), parameter :: k07 = 0.03065199508_double   ! 2*A*beta4
-    real(double), parameter :: k08 = -0.008858862267_double ! 2*k03/3
-    real(double), parameter :: k09 = 0.0787193029_double    ! k04/6
-    real(double), parameter :: k10 = 0.074361381067_double  ! k05/3
-    real(double), parameter :: k11 = 0.0509332762_double    ! k06/2
-    real(double), parameter :: k12 = 0.0204346633867_double ! 2*k07/3
-
-    xc_energy_total = zero
-    if (present(x_epsilon)) x_epsilon = zero
-    if (present(c_epsilon)) c_epsilon = zero
-
-    do n = 1, n_my_grid_points ! loop over grid pts and store potl on each
-       rho = spin_factor * density(n)  ! DRB Added to correct for lack of spin 2018/06/11
-
-       if (rho > RD_ERR) then ! Find radius of hole
-          rcp_rs = k00 * ( rho**third )
-       else
-          rcp_rs = zero
-       end if
-
-       ! ENERGY
-
-       ! Exchange
-       e_exchange = k01 * rcp_rs
-       if (present(x_epsilon)) x_epsilon(n) = e_exchange
-
-       ! Correlation
-       if (rcp_rs > zero) then
-          rs = one/rcp_rs
-       else
-          rs = zero
-       end if
-       sq_rs = sqrt(rs)
-
-       prefactor = k02 + k03*rs
-       denominator = sq_rs * ( k04 + sq_rs * ( k05 + sq_rs * ( k06 + k07 * sq_rs)))
-       if (denominator > zero) then
-          postfactor = log( one + one/denominator )
-       else
-          postfactor = 0
-       end if
-
-       e_correlation = prefactor * postfactor
-       if (present(c_epsilon)) c_epsilon(n) = e_correlation
-
-       ! Both exchange and correlation
-
-       xc_epsilon(n)   = e_exchange + e_correlation
-       xc_energy_total = xc_energy_total + xc_epsilon(n)*rho
-
-       ! POTENTIAL
-
-       ! Exchange
-
-       v_exchange = four_thirds * e_exchange
-
-       ! Correlation
-       !   (derivative of rho * e_correlation)
-
-       ! NOTE: delta_prefactor is actually the derivative of rho*prefactor
-       !       delta_postfactor is rho times the derivative of postfactor
-       delta_prefactor  = k02 + k08*rs
-       if (sq_rs > zero) then
-          delta_postfactor = &
-               sq_rs * (k09 + sq_rs*(k10 + sq_rs*(k11 + k12 * sq_rs))) / &
-                       (denominator * (1 + denominator))
-       else
-          delta_postfactor = 0
-       end if
-
-       v_correlation = delta_prefactor * postfactor + prefactor * delta_postfactor
-
-       xc_potential(n) = v_exchange + v_correlation
-
-
-    end do ! do n_my_grid_points
-    call gsum(xc_energy_total)
-    ! and 'integrate' the energy over the volume of the grid point
-    xc_energy_total = xc_energy_total * grid_point_volume
-
-    return
-  end subroutine get_xc_potential_LDA_PW92
-  !!***
-
-
-  !!****f* XC_modue/Vxc_of_r_LSDA_PW92 *
+  !!****f* XC_module/Vxc_of_r_LSDA_PW92 *
   !! PURPOSE
   !!   Calculates the exchange-correlation energy density and
   !!   potential as a function of rho(r) (evaluated at single grid
@@ -2566,484 +2531,548 @@ contains
   end subroutine get_xc_potential_hyb_PBE0
   !!*****
 
-
-  !!****f* XC_module/get_xc_potential_GGA_PBE_obsolete *
+  !!****f* XC/get_xc_energy *
   !!
   !!  NAME
-  !!   get_xc_potential_GGA_PBE_obsolete
+  !!   get_xc_energy
   !!  USAGE
   !!
   !!  PURPOSE
-  !!   Calculates the exchange-correlation potential
-  !!   on the grid within GGA using the
-  !!   Perdew-Burke-Ernzerhof. It also calculates the
-  !!   total exchange-correlation energy.
+  !!   Interface to CQ routines
+  !!  INPUTS
   !!
-  !!   Note that this is the functional described in
-  !!   Phys. Rev. Lett. 77, 3865 (1996)
+  !!  USES
   !!
-  !!   It is also (depending on an optional parameter)
-  !!     either revPBE, Phys. Rev. Lett. 80, 890 (1998),
-  !!     or RPBE, Phys. Rev. B 59, 7413 (1999)
+  !!  AUTHOR
+  !!   D. R. Bowler
+  !!  CREATION DATE
+  !!   2021/07/22
+  !!  MODIFICATION HISTORY
+  !!  SOURCE
+  !!
+  subroutine get_xc_energy(density, xc_energy, size)
+
+    use datatypes
+    use numbers
+    use global_module,               only: exx_niter, exx_siter, exx_alpha, nspin
+
+    implicit none
+
+    ! Passed variables
+    integer                    :: size
+    real(double)               :: xc_energy
+    real(double), dimension(size,nspin) :: density
+
+    ! Local variables
+    real(double) :: loc_x_energy, exx_tmp
+
+    if(flag_use_libxc) then
+       call get_libxc_energy(density, xc_energy, size)
+    else
+       select case(flag_functional_type)
+       case (functional_lda_pz81)
+          ! NOT SPIN POLARISED
+          call get_xc_energy_LDA_PZ81(density(:,1), xc_energy, size)
+          !
+          !
+       case (functional_lda_gth96)
+          ! NOT SPIN POLARISED
+          call get_GTH_xc_energy(density(:,1), xc_energy, size)
+          !
+          !
+       case (functional_lda_pw92)
+          call get_xc_energy_LSDA_PW92(density, xc_energy, size)
+          !
+          !
+       case (functional_gga_pbe96)
+          call get_xc_energy_GGA_PBE(density, xc_energy, size)
+          !
+          !
+       case (functional_gga_pbe96_rev98)
+          call get_xc_energy_GGA_PBE(density, xc_energy, size, functional_gga_pbe96_rev98 )
+          !
+          !
+       case (functional_gga_pbe96_r99)
+          call get_xc_energy_GGA_PBE(density, xc_energy, size, functional_gga_pbe96_r99 )
+          !
+          !
+       case (functional_gga_pbe96_wc)
+          call get_xc_energy_GGA_PBE(density, xc_energy, size, functional_gga_pbe96_wc )
+          !
+          !
+       case (functional_hyb_pbe0)
+          !
+          if ( exx_niter < exx_siter ) then
+             exx_tmp = one
+          else
+             exx_tmp = one - exx_alpha
+          end if
+          !
+          call get_xc_energy_hyb_PBE0(density, xc_energy, size, exx_tmp, functional_gga_pbe96 )
+          !
+          !
+       case (functional_hartree_fock)
+          ! **<lat>**
+          ! not optimal but experimental
+          if (exx_niter < exx_siter) then
+             ! for the first call of get_H_matrix using Hartree-Fock method
+             ! to get something not to much stupid ; use pure exchange functional
+             ! in near futur such as Xalpha
+             call get_xc_energy_LSDA_PW92(density, xc_energy, size)               
+          else
+             xc_energy    = zero
+          end if
+          !
+          !
+       case default
+          call get_xc_energy_LSDA_PW92(density, xc_energy, size)
+          !
+          !
+       end select
+    end if
+    return
+  end subroutine get_xc_energy
+  !!***
+
+  !!****f* XC_module/get_xc_energy_LDA_PZ81 *
+  !!
+  !!  NAME
+  !!   get_xc_energy_LDA_PZ81
+  !!  USAGE
+  !!
+  !!  PURPOSE
+  !!   Calculates the exchange-correlation energy
+  !!   on the grid within LDA using the Ceperley-Alder
+  !!   interpolation formula. 
+  !!
+  !!   Note that this is the Perdew-Zunger parameterisation of the
+  !!   Ceperley-Alder results for a homogeneous electron gas, as
+  !!   described in Phys. Rev. B 23, 5048 (1981), with Ceperley-Alder in
+  !!   Phys. Rev. Lett. 45, 566 (1980)
+  !!       Exchange energy: It can be found in:
+  !!                        Phys. Rev. B 45, 13244 (1992)
+  !!                      **See Eq. 26
+  !!       Correlation energy: The correlation functional is PZ-81
+  !!                           Phys. Rev. B 23, 5048 (1981)
+  !!                         **See Appendix C, and specially Table XII,
+  !!                             Eq. C1 for the xc hole (rs),
+  !!                             Eqs. C3 & C4, for rs > 1 and
+  !!                             Eqs. C5 & C6, for rs < 1
   !!  INPUTS
   !!
   !!
   !!  USES
   !!
   !!  AUTHOR
-  !!   A.S. Torralba
+  !!   E.H.Hernandez/DRB
   !!  CREATION DATE
-  !!   11/11/05
+  !!   02/03/95 and 2021/07/22
   !!  MODIFICATION HISTORY
-  !!   17/07/06 rgradient(1,:) used for storage of final result, before transform,
-  !!            instead of direct transform of the sum
-  !!            rgradient(1,:) + rgradient(2,:) + rgradient(3,:)
-  !!          (this was less efficient)
-  !!   15:55, 27/04/2007 drb
-  !!     Changed recip_vector, grad_density to (n,3) for speed
-  !!   2008/11/13 ast
-  !!     Added revPBE and RPBE
-  !!   2011/12/12 L.Tong
-  !!     Removed third, it is now defined in numbers_module
-  !!   2012/04/11 L.Tong
-  !!     Added optional parameters x_epsilon and c_epsilon to output
-  !!     the exchange and correlation parts of xc_epsilon respectively.
-  !!   2017/08/29 jack baker & dave
-  !!     Removed rcellx references (redundant)
   !!  SOURCE
   !!
-  subroutine get_xc_potential_GGA_PBE_obsolete(density, xc_potential, &
-                                               xc_epsilon, xc_energy, &
-                                               size, flavour,         &
-                                               x_epsilon, c_epsilon)
+  subroutine get_xc_energy_LDA_PZ81(density, xc_energy, size)
 
     use datatypes
     use numbers
-    use dimens,        only: grid_point_volume, n_my_grid_points
-    use GenComms,      only: gsum, cq_abort
-    use fft_module,    only: fft3, recip_vector
+    use GenComms,               only: gsum
+    use dimens,                 only: grid_point_volume, n_my_grid_points
+
+    implicit none
+
+    ! Passed variables
+    integer,                    intent(in)  :: size
+    real(double),               intent(out) :: xc_energy
+    real(double), dimension(:), intent(in)  :: density
+
+    ! Local variables
+    integer      :: n
+    real(double) :: denominator, e_correlation, e_exchange, ln_rs, &
+                    numerator, rcp_rs, rho, rs, rs_ln_rs, sq_rs,   &
+                    v_correlation, v_exchange
+    real(double), parameter :: alpha  = -0.45817_double
+    real(double), parameter :: beta_1 =  1.0529_double
+    real(double), parameter :: beta_2 =  0.3334_double
+    real(double), parameter :: gamma  = -0.1423_double
+    real(double), parameter :: p =  0.0311_double
+    real(double), parameter :: q = -0.048_double
+    real(double), parameter :: r =  0.0020_double
+    real(double), parameter :: s = -0.0116_double
+
+    xc_energy = zero
+
+    do n = 1, n_my_grid_points ! loop over grid pts and store potl on each
+       rho = spin_factor * density(n)  ! DRB Added to correct for lack of spin 2018/06/11
+       if (rho > RD_ERR) then ! Find radius of hole
+          rcp_rs = ( four_thirds * pi * rho )**(third)
+       else
+          rcp_rs = zero
+       end if
+       e_exchange = alpha * rcp_rs
+       if (rcp_rs>zero) then
+          rs = one/rcp_rs
+       else
+          rs = zero
+       end if
+       sq_rs = sqrt(rs)
+       if (rs>=one) then
+          denominator = one / (one + beta_1 * sq_rs + beta_2 * rs)
+          numerator   = one + seven_sixths * beta_1 * sq_rs +  &
+               four_thirds * beta_2 * rs
+          e_correlation = gamma * denominator
+       else if ((rs<one).and.(rs>RD_ERR)) then
+          ln_rs    = log(rs)
+          rs_ln_rs = rs * ln_rs
+          e_correlation = p * ln_rs + q  + r * rs_ln_rs + s * rs
+       else
+          e_correlation = zero
+       end if
+       xc_energy       = xc_energy  + (e_exchange + e_correlation) * spin_factor * density(n)  ! DRB Added to correct for lack of spin 2018/06/11
+    end do ! do n_my_grid_points
+    call gsum(xc_energy)
+    ! and 'integrate' the energy over the volume of the grid point
+    xc_energy = xc_energy * grid_point_volume
+
+    return
+  end subroutine get_xc_energy_LDA_PZ81
+  !!***
+
+
+  !!****f* XC_module/get_GTH_xc_energy *
+  !!
+  !!  NAME
+  !!   get_xc_energy
+  !!  USAGE
+  !!
+  !!  PURPOSE
+  !!   Calculates the exchange-correlation energy
+  !!   on the grid within LDA using the Ceperley-Alder
+  !!   interpolation formula. It also calculates the
+  !!   total exchange-correlation energy.
+  !!
+  !!   Note that this is the Goedecker/Teter/Hutter formula which
+  !!   involves only ratios of polynomials, and is rather easy to
+  !!   differentiate.  See PRB 54, 1703 (1996)
+  !!  INPUTS
+  !!
+  !!
+  !!  USES
+  !!
+  !!  AUTHOR
+  !!   D.R.Bowler
+  !!  CREATION DATE
+  !!   14:45, 25/03/2003 and 2021/07/22 14:51 
+  !!  MODIFICATION HISTORY
+  !!  SOURCE
+  !!
+  subroutine get_GTH_xc_energy(density, xc_energy, size)
+
+    use datatypes
+    use numbers
+    use global_module,          only: io_lun
+    use GenComms,               only: cq_abort, gsum
+    use dimens,                 only: grid_point_volume, n_my_grid_points
 
     implicit none
 
     ! Passed variables
     integer,      intent(in)  :: size
-    real(double), intent(in)  :: density(size)
-    real(double), intent(out) :: xc_potential(size), xc_epsilon(size)
     real(double), intent(out) :: xc_energy
-    ! optional
-    integer,intent(in), optional :: flavour
-    real(double), dimension(size), optional, intent(out) :: x_epsilon, c_epsilon
+    real(double), dimension(:), intent(in)  :: density
 
-    !     Local variables
-    integer :: n
-    integer :: selector
-
-    real(double), allocatable, dimension(:)   :: grad_density
-    real(double), allocatable, dimension(:,:) :: grad_density_xyz
-    real(double), allocatable, dimension(:)   :: ex_lda, ec_lda
-    real(double) :: rho, grad_rho, rho1_3, rho1_6, ks, s, s2, t, t2,   &
-                    A, At2, factor0, factor1, factor2, factor3,        &
-                    factor4, denominator0, numerator1, denominator1,   &
-                    num_den1, numerator2, dt2_drho, dA_drho,           &
-                    dnumerator1_drho, ddenominator1_drho,              &
-                    dnumerator1_dt2, dnumerator1_dA,                   &
-                    ddenominator1_dt2, ddenominator1_dA, dfactor2_dt2, &
-                    dfactor2_dnumerator1, dfactor2_ddenominator1,      &
-                    dfactor2_drho, dfactor3_dfactor2, dfactor3_drho
-    real(double) :: xc_energy_lda_total,                               &
-                    e_correlation_lda,                                 &
-                    de_correlation_lda,                                &
-                    e_exchange, e_correlation,                         &
-                    de_exchange, de_correlation,                       &
-                    dde_exchange, dde_correlation
-    real(double) :: df_dgrad_rho
-    real(double) :: kappa, mu_kappa
-    real(double) :: rpbe_exp
-    ! Gradient in reciprocal space
-    complex(double_cplx), allocatable, dimension(:,:) :: rgradient
-
-    !     From Phys. Rev. Lett. 77, 3865 (1996)
-    real(double), parameter :: mu = 0.21951_double
-    real(double), parameter :: beta = 0.066725_double
-    real(double), parameter :: gamma = 0.031091_double
-    real(double), parameter :: kappa_ori = 0.804_double
-
-    !     From Phys. Rev. Lett. 80, 890 (1998)
-    real(double), parameter :: kappa_alt = 1.245_double
-
-    !     Precalculated constants
-    real(double), parameter :: mu_kappa_ori = 0.27302_double     ! mu/kappa_ori
-    real(double), parameter :: mu_kappa_alt = 0.17631_double     ! mu/kappa_alt
-    real(double), parameter :: two_mu = 0.43902_double           ! 2*mu
-    real(double), parameter :: beta_gamma = 2.146119_double      ! beta/gamma
-    real(double), parameter :: beta_X_gamma = 0.002074546_double ! beta*gamma
-    real(double), parameter :: k01 = 0.16162045967_double        ! 1/(2*(3*pi*pi)**(1/3))
-    real(double), parameter :: k02 = -0.16212105381_double       ! -3*mu*((4*pi/3)**(1/3))/(2*pi*alpha)
-                                                                 ! =mu*k00*k01(LDA_PW92)=mu*k04
-    real(double), parameter :: k03 = 1.98468639_double           ! ((4/pi)*(3*pi*pi)**(1/3))**(1/2)
-    real(double), parameter :: k04 = -0.738558852965_double      ! -3*((4*pi/3)**(1/3))/(2*pi*alpha) = k00*k01 in LDA_PW92
-    real(double), parameter :: k05 = 0.05240415_double           ! -2*k01*k02
-    real(double), parameter :: k06 = -0.593801317784_double      ! k04*kappa_ori
-    real(double), parameter :: k07 = -0.984745137287_double      ! 4*k04/3
-    real(double), parameter :: seven_thirds = 2.333333333_double ! 7/3
-
-    integer :: stat
-    !      Selector options
-    integer, parameter :: fx_original    = 1                     ! Used in PBE and revPBE
-    integer, parameter :: fx_alternative = 2                     ! Used in RPBE
-
-    ! Choose between PBE or revPBE parameters
-    if(PRESENT(flavour)) then
-      if(flavour==functional_gga_pbe96_rev98) then
-        kappa=kappa_alt
-        mu_kappa=mu_kappa_alt
-      else
-        kappa=kappa_ori
-        mu_kappa=mu_kappa_ori
-      end if
-    else
-      kappa=kappa_ori
-      mu_kappa=mu_kappa_ori
-    end if
-
-    if (present(x_epsilon)) then
-       allocate(ex_lda(size), STAT=stat)
-       if (stat /= 0) &
-            call cq_abort("Error allocating ex_lda for PBE functional: ", stat)
-    end if
-
-    if (present(c_epsilon)) then
-       allocate(ec_lda(size), STAT=stat)
-       if (stat /= 0) &
-            call cq_abort("Error allocating ec_lda for PBE functional ", stat)
-    end if
-
-    allocate(grad_density(size), grad_density_xyz(size,3),&
-             rgradient(size,3),STAT = stat)
-    !initialisation  2010.Oct.30 TM
-    grad_density(:) = zero
-    grad_density_xyz(:,:) = zero
-    rgradient(:,:) = zero
-    xc_epsilon(:) = zero
-    xc_potential(:) = zero
-    if (present(x_epsilon)) then
-       x_epsilon = zero
-       ex_lda = zero
-    end if
-    if (present(c_epsilon)) then
-       c_epsilon = zero
-       ec_lda = zero
-    end if
-    if (stat /= 0) &
-         call cq_abort("Error allocating arrays for PBE functional: ", stat)
-
-    ! Choose functional form
-    if (present(flavour)) then
-       if (flavour == functional_gga_pbe96_r99) then
-          selector = fx_alternative
-       else
-          selector = fx_original
-       end if
-    else
-       selector = fx_original
-    end if
-
-    ! Build the gradient of the density
-    call build_gradient(density, grad_density_xyz, size)
-
-    grad_density(:) = sqrt(grad_density_xyz(:,1)**2 + &
-                           grad_density_xyz(:,2)**2 + &
-                           grad_density_xyz(:,3)**2)
-
-    ! Get the LDA part of the functional
-    if (present(x_epsilon) .and. present(c_epsilon)) then
-       call get_xc_potential_LDA_PW92(density, xc_potential, xc_epsilon, &
-                                      xc_energy_lda_total, size,         &
-                                      x_epsilon=ex_lda,                  &
-                                      c_epsilon=ec_lda)
-    else if (present(x_epsilon)) then
-       call get_xc_potential_LDA_PW92(density, xc_potential, xc_epsilon, &
-                                      xc_energy_lda_total, size,         &
-                                      x_epsilon=ex_lda)
-    else if (present(c_epsilon)) then
-       call get_xc_potential_LDA_PW92(density, xc_potential, xc_epsilon, &
-                                      xc_energy_lda_total, size,         &
-                                      c_epsilon=ec_lda)
-    else
-       call get_xc_potential_LDA_PW92(density, xc_potential, xc_epsilon, &
-                                      xc_energy_lda_total, size)
-    end if
+    ! Local variables
+    integer n
+    real(double) :: denominator, e_correlation, e_exchange, ln_rs,    &
+                    numerator, rcp_rs, rho, rs, rs_ln_rs, sq_rs,      &
+                    v_correlation, v_exchange, drs_dRho, t1, t2, dt1, &
+                    dt2
+    real(double), parameter :: a0=0.4581652932831429_double
+    real(double), parameter :: a1=2.217058676663745_double
+    real(double), parameter :: a2=0.7405551735357053_double
+    real(double), parameter :: a3=0.01968227878617998_double
+    real(double), parameter :: b1=1.000000000000000_double
+    real(double), parameter :: b2=4.504130959426697_double
+    real(double), parameter :: b3=1.110667363742916_double
+    real(double), parameter :: b4=0.02359291751427506_double
 
     xc_energy = zero
     do n = 1, n_my_grid_points ! loop over grid pts and store potl on each
-       rho = density(n)
-       grad_rho = grad_density(n)
-
-       !!!!!!   XC GGA ENERGY
-
-       ! Exchange
-
-       if (rho > RD_ERR) then
-          rho1_3 = rho ** third
-          rho1_6 = sqrt (rho1_3)
-          s = k01 * grad_rho / (rho ** four_thirds)
-          s2 = s * s
-          if(selector == fx_alternative) then           ! RPBE
-            rpbe_exp = exp(-mu_kappa * s2)
-            e_exchange = k06*rho1_3*(1.0_double-rpbe_exp)
-          else                                          ! PBE, revPBE
-            denominator0 = 1.0 / (1.0 + mu_kappa * s2)
-            factor0 = k02 * rho1_3
-            factor1 = s2 * denominator0
-            ! NOTE: This doesn't look like in Phys. Rev. Lett. 77:18,
-            !       3865 (1996) because the 1 in Fx, has been
-            !       multiplied by Ex-LDA and is implicit in
-            !       xc_energy_lda(n), in the total energy below
-            e_exchange = factor0 * factor1
-          end if
+       rho = spin_factor * density(n)  ! DRB Added to correct for lack of spin 2018/06/11
+       if (rho > RD_ERR) then ! Find radius of hole
+          rcp_rs = ( four*third * pi * rho )**(third)
+          rs     = one/rcp_rs
        else
-          e_exchange = zero
+          rcp_rs = zero
+          rs     = zero
        end if
-
-       if (present(x_epsilon)) x_epsilon(n) = e_exchange + ex_lda(n)
-
-       ! Correlation
-
-       if (rho > RD_ERR) then
-          e_correlation_lda = xc_epsilon(n) - k04 * rho1_3
-
-          ! t=grad_rho/(2*rho*ks); ks=sqrt(4*kf/pi); kf=(3*pi*pi*rho)**(1/3); s=grad_rho/(2*rho*kf)
-          ks = k03 * rho1_6
-          t = grad_rho / ( 2 * ks * rho )
-          t2 = t * t
-
-          A = exp(-e_correlation_lda / gamma) - 1.0
-          if (A > RD_ERR) then
-             A = beta_gamma / A
-          else
-             A = beta_gamma * BIG
-          end if
-
-          At2 = A * t2
-          numerator1 = 1.0 + At2
-          denominator1 = 1.0 + At2 + At2 * At2
-          num_den1 = numerator1 / denominator1
-
-          factor2 = t2 * num_den1
-          factor3 = gamma * log(one + beta_gamma * factor2)
-
-          e_correlation = factor3;  !gamma * log( 1.0 + beta_gamma * t2 * num_den1 )
-       else
-          e_correlation = zero
+       if (rs > zero) then
+          drs_dRho = -rs / (3.0 * rho)
+          t1  = a0 + rs*(a1 + rs * (a2 + rs * a3))
+          t2  = rs * (b1 + rs * (b2 + rs * (b3 + rs * b4)))
+          dt1 = a1 + rs * (2.0 * a2 + rs * 3.0 * a3)
+          dt2 = b1 + rs * (2.0 * b2 + rs * (3.0 * b3 + rs * 4.0 * b4))
+          xc_energy = xc_energy - (t1/t2)*rho
        end if
-
-       if (present(c_epsilon)) c_epsilon(n) = e_correlation + ec_lda(n)
-
-       !*ast* TEST-POINT 1
-       ! Both exchange and correlation
-       xc_energy = xc_energy + (xc_epsilon(n) + e_exchange + e_correlation)*rho
-       ! Only LDA part
-       !xc_energy = xc_energy + (xc_epsilon(n))*rho
-       ! LDA + exchange
-       !xc_energy = xc_energy + (xc_epsilon(n) + e_exchange)*rho
-       ! Only exchange
-       !xc_energy = xc_energy + (e_exchange)*rho
-       ! LDA + correlation
-       !xc_energy = xc_energy + (xc_epsilon(n) + e_correlation)*rho
-       ! Only correlation
-       !xc_energy = xc_energy + (e_correlation)*rho
-
-       !!!!!!   POTENTIAL
-
-       !!!   Terms due to df/drho
-
-       ! Exchange
-
-       if (rho > RD_ERR) then
-          if(selector == fx_alternative) then           ! RPBE
-            de_exchange = k07 * rho1_3 * (kappa - (two_mu * s2 + kappa) * rpbe_exp)
-          else                                          ! PBE, revPBE
-            de_exchange = four_thirds * factor0 * factor1 * ( 1 - 2* denominator0 )
-          end if
-       else
-          de_exchange = zero
-       end if
-
-       ! Correlation
-
-       if (rho > RD_ERR) then
-          de_correlation_lda = ( xc_potential(n) &
-                               - four_thirds * k04 * rho1_3 &
-                               - e_correlation_lda ) / rho
-
-          dt2_drho = -seven_thirds * t2 / rho
-          dA_drho  = A * A * exp(-e_correlation_lda / gamma ) * de_correlation_lda / beta
-          dnumerator1_dt2   = A
-          dnumerator1_dA    = t2
-          factor4 = 1.0 + 2 * At2
-          ddenominator1_dt2 = A * factor4
-          ddenominator1_dA  = t2 * factor4
-          dnumerator1_drho   = dnumerator1_dt2 * dt2_drho &
-                             + dnumerator1_dA * dA_drho
-          ddenominator1_drho = ddenominator1_dt2 * dt2_drho &
-                             + ddenominator1_dA * dA_drho
-          dfactor2_dt2 = num_den1
-          dfactor2_dnumerator1   = t2 / denominator1
-          dfactor2_ddenominator1 = -factor2 / denominator1
-          dfactor2_drho = dfactor2_dt2 * dt2_drho &
-                        + dfactor2_dnumerator1 * dnumerator1_drho &
-                        + dfactor2_ddenominator1 * ddenominator1_drho
-          dfactor3_dfactor2 = beta / ( 1.0 + beta_gamma * factor2 )
-          dfactor3_drho = dfactor3_dfactor2 * dfactor2_drho
-          de_correlation = factor3 + rho * dfactor3_drho
-       else
-          de_correlation = zero
-       end if
-
-       !*ast* TEST-POINT 2
-       xc_potential(n) = xc_potential(n) + de_exchange + de_correlation
-       ! Only LDA part
-       !xc_potential(n) = xc_potential(n)
-       ! LDA + exchange
-       !xc_potential(n) = xc_potential(n) + de_exchange
-       ! Only exchange
-       !xc_potential(n) = de_exchange
-       ! LDA + correlation
-       !xc_potential(n) = xc_potential(n) + de_correlation
-       ! Only correlation
-       !xc_potential(n) = de_correlation
-
-       !!!   Terms due to df/d|grad_rho|
-
-       ! Exchange
-
-       if (rho > RD_ERR) then
-          if(selector == fx_alternative) then           ! RPBE
-             dde_exchange = -k05 * s * rpbe_exp
-          else                                          ! PBE, revPBE
-             dde_exchange = -k05 * s * denominator0 * denominator0!factor1 * denominator0
-          end if
-       else
-          dde_exchange = zero
-       end if
-
-       ! Correlation
-
-       if (rho > RD_ERR) then
-          numerator2 = beta_X_gamma * t * ( 1.0 + 2.0 * At2 ) &
-                     / (( gamma * denominator1 + beta * t2 * numerator1 ) * denominator1)
-          dde_correlation = numerator2 / ks;
-       else
-          dde_correlation = zero
-       end if
-
-       ! Normalisation (modulus of gradient)
-
-       !*ast* TEST-POINT 3
-       if(abs(grad_density(n)) > RD_ERR) then  !DEBUG
-       df_dgrad_rho = (dde_exchange + dde_correlation) / grad_density(n)
-       else                 !DEBUG
-       df_dgrad_rho = zero   !DEBUG
-       endif                !DEBUG
-       ! Only LDA part
-       !df_dgrad_rho = 0.0
-       ! LDA + exchange
-       !df_dgrad_rho = dde_exchange / grad_density(n)
-       ! Only exchange
-       !df_dgrad_rho = dde_exchange / grad_density(n)
-       ! LDA + correlation
-       !df_dgrad_rho = dde_correlation / grad_density(n)
-       ! Only correlation
-       !df_dgrad_rho = dde_correlation / grad_density(n)
-
-
-       ! Gradient times derivative of energy
-
-       grad_density_xyz(n,1) = grad_density_xyz(n,1)*df_dgrad_rho
-       grad_density_xyz(n,2) = grad_density_xyz(n,2)*df_dgrad_rho
-       grad_density_xyz(n,3) = grad_density_xyz(n,3)*df_dgrad_rho
-
-       !xc_epsilon  !2010.Oct.30 TM
-       xc_epsilon(n) = xc_epsilon(n) + e_exchange + e_correlation
-       !*ast* TEST-POINT 4
-       !TM delta_E_xc = delta_E_xc + (xc_epsilon(n) + e_exchange + e_correlation)*rho
-       ! Only LDA part
-       !delta_E_xc = delta_E_xc + (xc_epsilon(n))*rho
-       ! LDA + exchange
-       !delta_E_xc = delta_E_xc + (xc_epsilon(n) + e_exchange)*rho
-       ! Only exchange
-       !delta_E_xc = delta_E_xc + (e_exchange)*rho
-       ! LDA + correlation
-       !delta_E_xc = delta_E_xc + (xc_epsilon(n) + e_correlation)*rho
-       ! Only correlation
-       !delta_E_xc = delta_E_xc + (e_correlation)*rho
-
     end do ! do n_my_grid_points
-
-
-    !!!   Final steps of the energy calculation
-
-    ! Add the energies and 'integrate' over the volume of the grid points
-
     call gsum(xc_energy)
+    ! and 'integrate' the energy over the volume of the grid point
     xc_energy = xc_energy * grid_point_volume
-
-    ! Fourier transform the gradient, component by component
-
-    call fft3(grad_density_xyz(:,1), rgradient(:,1), size, -1 )
-    call fft3(grad_density_xyz(:,2), rgradient(:,2), size, -1 )
-    call fft3(grad_density_xyz(:,3), rgradient(:,3), size, -1 )
-
-    !!!   Get the second term of the potential by taking derivatives
-
-    ! First, get the scalar product of the (normalised) gradient and the wave vector (times i)
-
-    rgradient(:,1) = -rgradient(:,1)*minus_i*recip_vector(:,1)
-    rgradient(:,1) = rgradient(:,1) - rgradient(:,2)*minus_i*recip_vector(:,2)
-    rgradient(:,1) = rgradient(:,1) - rgradient(:,3)*minus_i*recip_vector(:,3)
-
-    ! Add terms of the scalar product and then Fourier transform back the resultant vector
-    ! NOTE: Store the result in the modulus of the gradient (not needed anymore) to save memory
-
-    call fft3( grad_density, rgradient(:,1), size, 1 )
-
-    ! Finally, get the potential
-    ! NOTE that here grad_density is NOT the modulus of the gradient,
-    !      but a term of the potential (see Fourier transform above)
-
-    do n=1,n_my_grid_points
-        xc_potential(n) = xc_potential(n) - grad_density(n)
-    end do
-
-    ! I changed the order of deallocation, because I was told that deallocation
-    ! of the latest allocated array should be done first.
-    ! (though I am not sure whether it is true or not)   2010.Oct.30 TM
-
-    if(allocated(rgradient)) then
-       deallocate(rgradient,STAT=stat)
-       if(stat/=0) call cq_abort("Error deallocating rgradient",stat)
-    end if
-    if(allocated(grad_density_xyz)) then
-       deallocate(grad_density_xyz,STAT=stat)
-       if(stat/=0) call cq_abort("Error deallocating grad_density_xyz",stat)
-    end if
-    if(allocated(grad_density)) then
-       deallocate(grad_density,STAT=stat)
-       if(stat/=0) call cq_abort("Error deallocating grad_density",stat)
-    end if
-    if (allocated(ex_lda)) then
-       deallocate(ex_lda,STAT=stat)
-       if (stat /= 0) call cq_abort("Error deallocating ex_lda", stat)
-    end if
-    if (allocated(ec_lda)) then
-       deallocate(ec_lda,STAT=stat)
-       if (stat /= 0) call cq_abort("Error deallocating ec_lda", stat)
-    end if
-
     return
-  end subroutine get_xc_potential_GGA_PBE_obsolete
+  end subroutine get_GTH_xc_energy
   !!***
 
+  !!****f* XC_module/get_xc_energy_LSDA_PW92 *
+  !!
+  !!  NAME
+  !!   get_xc_energy_LSDA_PW92
+  !!  USAGE
+  !!
+  !!  PURPOSE
+  !!   Calculates the spin polarized exchange-correlation
+  !!   energy on the grid within LDA using the Ceperley-Alder
+  !!   interpolation formula. It also calculates the total
+  !!   exchange-correlation energy.
+  !!
+  !!   Note that this is the Perdew-Wang parameterisation of the
+  !!   Ceperley-Alder results for a homogeneous electron gas, as
+  !!   described in Phys. Rev. B 45, 13244 (1992), with Ceperley-Alder
+  !!   in Phys. Rev. Lett. 45, 566 (1980) INPUTS
+  !!
+  !!  USES
+  !!
+  !!  AUTHOR
+  !!   L. Tong and DRB
+  !!  CREATION DATE
+  !!   22/03/2011 and 2021/07/22 14:52
+  !!  MODIFICATION HISTORY
+  !!  SOURCE
+  !!
+  subroutine get_xc_energy_LSDA_PW92(density, xc_energy_total, size)
+
+    use datatypes
+    use numbers
+    use GenComms,               only: cq_abort, gsum
+    use dimens,                 only: grid_point_volume, n_my_grid_points
+    use global_module,          only: nspin
+
+    implicit none
+
+    ! Passed variables
+    ! size of the real space grid
+    integer,                      intent(in)  :: size
+    real(double),                 intent(out) :: xc_energy_total
+    real(double), dimension(:,:), intent(in)  :: density
+
+    ! Local variables
+    integer      :: rr, spin
+    real(double) :: eps_x, eps_c, rho_tot_r
+    real(double), dimension(nspin) :: rho_r, Vx, Vc
+
+    ! initialisation
+    xc_energy_total = zero
+
+    ! loop over grid points on each node
+    do rr = 1, n_my_grid_points
+       rho_r(1:nspin) = density(rr,1:nspin)
+       rho_tot_r      = rho_r(1) + rho_r(nspin)
+       call Vxc_of_r_LSDA_PW92(nspin, rho_r, eps_x=eps_x, eps_c=eps_c,&
+                               Vx=Vx, Vc=Vc)
+
+       xc_energy_total = xc_energy_total + (eps_x + eps_c)  * rho_tot_r
+    end do
+    call gsum(xc_energy_total)
+    xc_energy_total = xc_energy_total * grid_point_volume
+    return
+  end subroutine get_xc_energy_LSDA_PW92
+  !!***
+
+  !!****f* XC_module/get_xc_energy_GGA_PBE
+  !! PURPOSE
+  !!   Calculates the exchange-correlation energy
+  !!   on the grid within GGA using three flavours of
+  !!   Perdew-Burke-Ernzerhof. It also calculates the
+  !!   total exchange-correlation energy.
+  !!
+  !!   flavour not defined
+  !!     use original PBE, PRL 77, 3865 (1996)
+  !!   flavour = functional_gga_pbe96_rev98:
+  !!     use revPBE, PRL 80, 890 (1998)
+  !!   flavour = functional_gga_pbe96_r99:
+  !!     use RPBE, PRB 59, 7413 (1999)
+  !!
+  !! USAGE
+  !!   call get_xc_energy_GGA_PBE(density, xc_potential,      &
+  !!                                 xc_epsilon, xc_energy, size,&
+  !!                                 flavour)
+  !! INPUTS
+  !!   integer      size                : size of the real space grid
+  !!   integer      flavour             : flavour of PBE functional (optional)
+  !!   real(double) density(size,nspin) : spin dependent density
+  !! OUTPUT
+  !!   real(double) xc_energy                : total xc-energy (sum over spin)
+  !!   real(double) xc_epsilon(size)         : xc-energy density
+  !!   real(double) xc_potential(size,nspin) : xc-potnetial
+  !! AUTHOR
+  !!   L.Tong and DRB
+  !! CREATION DATE 
+  !!   2012/04/27 and 2021/07/22 14:54 dave
+  !! MODIFICATION HISTORY
+  !! SOURCE
+  !!
+  subroutine get_xc_energy_GGA_PBE(density, xc_energy, grid_size, flavour)
+
+    use datatypes
+    use numbers
+    use global_module, only: nspin, flag_stress, flag_full_stress
+    use dimens,        only: grid_point_volume, n_my_grid_points
+    use GenComms,      only: gsum, cq_abort
+    use fft_module,    only: fft3, recip_vector
+    use memory_module, only: reg_alloc_mem, reg_dealloc_mem, type_dbl
+
+    implicit none
+
+    ! passed variables
+    integer,                      intent(in)  :: grid_size
+    real(double), dimension(:,:), intent(in)  :: density
+    real(double),                 intent(out) :: xc_energy
+    integer,      optional,       intent(in)  :: flavour
+
+    ! local variables
+    integer      :: PBE_type
+    integer      :: rr, spin, stat, dir1, dir2
+    real(double) :: eps_x, eps_c, rho_tot_r
+    real(double),         dimension(nspin)        :: rho_r
+    real(double),         dimension(3,nspin)      :: grho_r
+    real(double),         dimension(:,:,:), allocatable :: grad_density
+
+    allocate(grad_density(grid_size,3,nspin), STAT=stat)
+    if (stat /= 0) call cq_abort("get_xc_potential_GGA_PBE: Error alloc mem: ", grid_size)
+    call reg_alloc_mem(area_ops, grid_size*3*nspin, type_dbl)
+
+    if (present(flavour)) then
+       PBE_type = flavour
+    else
+       PBE_type = functional_gga_pbe96
+    end if
+
+    ! initialisation
+    grad_density = zero
+    xc_energy    = zero
+
+    ! Build the gradient of the density
+    do spin = 1, nspin
+       call build_gradient(density(:,spin), grad_density(:,:,spin), grid_size)
+    end do
+
+    do rr = 1, n_my_grid_points
+       rho_tot_r = density(rr,1) + density(rr,nspin)
+       do spin = 1, nspin
+          rho_r(spin)      = density(rr,spin)
+          grho_r(1:3,spin) = grad_density(rr,1:3,spin)
+       end do
+       call eps_xc_of_r_GGA_PBE(nspin, PBE_type, rho_r, grho_r, &
+                                eps_x=eps_x, eps_c=eps_c)
+       xc_energy      = xc_energy + rho_tot_r * (eps_x + eps_c)
+    end do ! rr
+    call gsum(xc_energy)
+    xc_energy = xc_energy * grid_point_volume
+    deallocate(grad_density, STAT=stat)
+    if (stat /= 0) call cq_abort("get_xc_potential_GGA_PBE: Error dealloc mem")
+    call reg_dealloc_mem(area_ops, grid_size*3*nspin, type_dbl)
+
+  end subroutine get_xc_energy_GGA_PBE
+  !!*****
+
+
+  !!****f* XC_module/get_xc_energy_hyb_PBE0
+  !! PURPOSE
+  !!
+  !!   Work routine based on get_xc_energy_GGA_PBE.
+  !!   It will be recoded in near futur to handle any hybrid functional.
+  !!   For now just handle one coefficient as in PBE0.
+  !! USAGE
+  !!
+  !! INPUTS
+  !!
+  !!   integer      size                : size of the real space grid
+  !!   integer      flavour             : flavour of PBE functional (optional)
+  !!   real(double) density(size,nspin) : spin dependent density
+  !! OUTPUT
+  !!   real(double) xc_energy                : total xc-energy (sum over spin)
+  !!
+  !! AUTHOR
+  !!   L.Tong/L.Truflandier/DRB
+  !! CREATION DATE
+  !!   2014/09/24 and 2021/07/22 15:00 dave
+  !! MODIFICATION HISTORY
+  !! SOURCE
+  !!
+  subroutine get_xc_energy_hyb_PBE0(density, xc_energy, grid_size, exx_a, flavour )
+    use datatypes
+    use numbers
+    use global_module, only: nspin, flag_full_stress, flag_stress
+    use dimens,        only: grid_point_volume, n_my_grid_points
+    use GenComms,      only: gsum, cq_abort
+    use fft_module,    only: fft3, recip_vector
+    use memory_module, only: reg_alloc_mem, reg_dealloc_mem, type_dbl
+
+    implicit none
+
+    ! passed variables
+    integer,                      intent(in)  :: grid_size
+    real(double), dimension(:,:), intent(in)  :: density
+    real(double),                 intent(out) :: xc_energy
+    integer,      optional,       intent(in)  :: flavour
+    real(double),                 intent(in)  :: exx_a
+
+    ! local variables
+    integer      :: PBE_type
+    integer      :: rr, spin, stat, dir1, dir2
+    real(double) :: eps_x, eps_c, rho_tot_r
+    real(double),         dimension(nspin)        :: rho_r
+    real(double),         dimension(3,nspin)      :: grho_r
+    real(double),         dimension(:,:,:), allocatable :: grad_density
+
+    allocate(grad_density(grid_size,3,nspin), STAT=stat)
+    if (stat /= 0) call cq_abort("get_xc_potential_GGA_PBE: Error alloc mem: ", grid_size)
+    call reg_alloc_mem(area_ops, grid_size*3*nspin, type_dbl)
+
+    if (present(flavour)) then
+       PBE_type = flavour
+    else
+       PBE_type = functional_gga_pbe96
+    end if
+
+    ! setup exx_a
+
+    ! Initialisation
+    grad_density = zero
+    xc_energy    = zero
+
+    ! Build the gradient of the density
+    do spin = 1, nspin
+       call build_gradient(density(:,spin), grad_density(:,:,spin), grid_size)
+    end do
+
+    do rr = 1, n_my_grid_points
+       rho_tot_r = density(rr,1) + density(rr,nspin)
+       do spin = 1, nspin
+          rho_r(spin)      = density(rr,spin)
+          grho_r(1:3,spin) = grad_density(rr,1:3,spin)
+       end do
+       call eps_xc_of_r_GGA_PBE(nspin, PBE_type, rho_r, grho_r, &
+                                eps_x    =eps_x, &
+                                eps_c    =eps_c)
+       xc_energy      = xc_energy + rho_tot_r * (exx_a * eps_x + eps_c)
+    end do ! rr
+    call gsum(xc_energy)
+    xc_energy = xc_energy * grid_point_volume
+    deallocate(grad_density, STAT=stat)
+    if (stat /= 0) call cq_abort("get_xc_potential_GGA_PBE: Error dealloc mem")
+    call reg_dealloc_mem(area_ops, grid_size*3*nspin, type_dbl)
+
+    return
+  end subroutine get_xc_energy_hyb_PBE0
+  !!*****
 
   !!****f* XC_module/build_gradient *
   !!

--- a/src/XC_LibXC_v5_module.f90
+++ b/src/XC_LibXC_v5_module.f90
@@ -25,6 +25,8 @@
 !!   2021/05/12 tsuyoshi, dave and others
 !!    Created interface for LibXC v5
 !!    Main changes involve XC types and function calls
+!!   2021/07/22 14:26 dave
+!!    Added get_xc_energy routine (and associated)
 !! SOURCE
 !!
 module XC
@@ -48,7 +50,7 @@ module XC
   logical, public :: flag_different_functional
 
   ! Public methods
-  public :: get_xc_potential, get_dxc_potential, init_xc
+  public :: get_xc_potential, get_dxc_potential, init_xc, get_xc_energy
 
   ! LibXC variables
   integer :: n_xc_terms
@@ -1044,6 +1046,140 @@ contains
   end subroutine get_libxc_dpotential
   !!***
 
+  !!****f* XC_module/get_libxc_energy *
+  !!
+  !!  NAME
+  !!   get_libxc_energy
+  !!  USAGE
+  !!
+  !!  PURPOSE
+  !!   Calculates the exchange-correlation energy
+  !!   on the grid using LibXC
+  !!  INPUTS
+  !!
+  !!  USES
+  !!
+  !!  AUTHOR
+  !!   D. R. Bowler
+  !!  CREATION DATE
+  !!   2021/07/22
+  !!  MODIFICATION HISTORY
+  !!  SOURCE
+  !!
+  subroutine get_libxc_energy(density, xc_energy, size)
+
+    use datatypes
+    use numbers
+    use GenComms,      only: gsum
+    use GenBlas,       only: dot
+    use dimens,        only: grid_point_volume, n_my_grid_points
+    use global_module, only : nspin, io_lun, flag_full_stress, flag_stress
+    use fft_module,    only: fft3, recip_vector
+
+    implicit none
+
+    ! Passed variables
+    integer,                      intent(in)  :: size
+    real(double),                 intent(out) :: xc_energy
+    real(double), dimension(:,:), intent(in)  :: density
+
+    ! local variables
+    real(double), dimension(:), allocatable :: sigma, eps ! Temporary variables
+    real(double), dimension(:), allocatable :: alt_dens, xc_epsilon
+    real(double), dimension(:,:,:), allocatable :: grad_density
+    real(double) :: rho_tot
+    integer :: stat, i, spin, nxc, j
+
+    ! Storage space for individual components
+    allocate(eps(n_my_grid_points),alt_dens(n_my_grid_points*nspin))
+    ! For GGA, create sigma (\nabla n dot \nabla n) from gradient
+    if(flag_is_GGA) then
+       if(nspin>1) then
+          allocate(sigma(n_my_grid_points*3))
+       else
+          allocate(sigma(n_my_grid_points))
+       endif
+       ! If GGA, we need to find and adapt gradient
+       allocate(grad_density(size,3,nspin),STAT=stat)
+       sigma = zero
+       grad_density = zero
+       do spin = 1, nspin
+          call build_gradient(density(:,spin), grad_density(:,:,spin), size)
+       end do
+       ! Build modulus - NB LibXC uses spin, point for density !
+       if(nspin>1) then
+          ! This is ugly, but there's not really a better way
+          do i=1,n_my_grid_points
+             ! \nabla n_alpha dot \nabla n_alpha
+             sigma(1+(i-1)*3) = &
+               grad_density(i,1,1)*grad_density(i,1,1) + &
+               grad_density(i,2,1)*grad_density(i,2,1) + &
+               grad_density(i,3,1)*grad_density(i,3,1)
+             ! \nabla n_alpha dot \nabla n_beta
+             sigma(2+(i-1)*3) = &
+               grad_density(i,1,1)*grad_density(i,1,2) + &
+               grad_density(i,2,1)*grad_density(i,2,2) + &
+               grad_density(i,3,1)*grad_density(i,3,2)
+             ! \nabla n_beta dot \nabla n_beta
+             sigma(3+(i-1)*3) = &
+               grad_density(i,1,2)*grad_density(i,1,2) + &
+               grad_density(i,2,2)*grad_density(i,2,2) + &
+               grad_density(i,3,2)*grad_density(i,3,2)
+          end do
+       else
+          sigma(1:n_my_grid_points) = &
+               grad_density(1:n_my_grid_points,1,1)*grad_density(1:n_my_grid_points,1,1) + &
+               grad_density(1:n_my_grid_points,2,1)*grad_density(1:n_my_grid_points,2,1) + &
+               grad_density(1:n_my_grid_points,3,1)*grad_density(1:n_my_grid_points,3,1)
+       end if
+    end if
+    ! If we have spin, re-order density to have spin index first
+    ! Otherwise scale
+    if(nspin>1) then
+       do i = 1, n_my_grid_points
+          do spin=1,nspin
+             alt_dens(spin + (i-1)*nspin) = density(i,spin)
+          end do
+       end do
+    else
+       ! Scaling for spin; sigma needs four because it is nabla n .dot. nabla n
+       alt_dens(1:n_my_grid_points) = two*density(1:n_my_grid_points,1)
+       if(flag_is_GGA) then
+          sigma(:) = four*sigma(:)
+          grad_density(:,:,1) = two*grad_density(:,:,1)
+       end if
+    end if
+    ! Create XC energy
+    allocate(xc_epsilon(n_my_grid_points))
+    xc_epsilon = zero
+    do nxc = 1,n_xc_terms
+       eps = zero
+       select case( i_xc_family(nxc) )
+       case(XC_FAMILY_LDA)
+          call xc_f90_lda_exc( xc_func(nxc), int(n_my_grid_points,kind=wide), alt_dens, eps )
+       case(XC_FAMILY_GGA)
+          call xc_f90_gga_exc( xc_func(nxc), int(n_my_grid_points,kind=wide), alt_dens, sigma, eps )
+       end select
+       xc_epsilon(1:n_my_grid_points) = xc_epsilon(1:n_my_grid_points) + eps(1:n_my_grid_points)
+    end do ! nxc = n_xc_terms
+    ! Sum to get energy
+    xc_energy = zero
+    do i=1,n_my_grid_points
+       rho_tot = density(i,1) + density(i,nspin)
+       xc_energy = xc_energy + xc_epsilon(i)*rho_tot
+    end do
+    call gsum(xc_energy)
+    ! and 'integrate' the energy over the volume of the grid point
+    xc_energy = xc_energy * grid_point_volume
+
+    deallocate(eps,alt_dens,xc_epsilon)
+    if(flag_is_GGA)then
+       deallocate(grad_density,sigma)
+    end if
+    return
+  end subroutine get_libxc_energy
+  !!***
+
   ! **********************************
   ! Conquest XC routines go below here
   ! **********************************
@@ -1304,175 +1440,7 @@ contains
   end subroutine get_GTH_xc_potential
   !!***
 
-
-  !!****f* XC_module/get_xc_potential_LDA_PW92 (Obsolete)*
-  !!
-  !!  NAME
-  !!   get_xc_potential_LDA_PW92 (Obsolete)
-  !!  USAGE
-  !!
-  !!  PURPOSE
-  !!   Calculates the exchange-correlation potential on the grid within
-  !!   LDA using the Ceperley-Alder interpolation formula. It also
-  !!   calculates the total exchange-correlation energy.
-  !!
-  !!   Note that this is the Perdew-Wang parameterisation of the
-  !!   Ceperley-Alder results for a homogeneous electron gas, as
-  !!   described in Phys. Rev. B 45, 13244 (1992), with Ceperley-Alder
-  !!   in Phys. Rev. Lett. 45, 566 (1980)
-  !!  INPUTS
-  !!
-  !!  USES
-  !!
-  !!  AUTHOR
-  !!   A.S. Torralba
-  !!  CREATION DATE
-  !!   01/11/05
-  !!  MODIFICATION HISTORY
-  !!   2008/03/03 18:32 dave
-  !!    Removed dsqrt
-  !!   2011/03/22 L.Tong
-  !!    Removed local definition of third, it is now defined in numbers
-  !!    module Changed 1 to one in the log() functions
-  !!   2012/04/03 L.Tong
-  !!   - Added optional variables x_epsilon and c_epsilon so that if
-  !!     present they will store the output for the exchange and
-  !!     correlation parts of xc_epsilon respectively
-  !!   2012/04/25 L.Tong
-  !!   *** THIS SUBROUTINE IS NOW OBSOLETE, USE THE LSDA VERSION ***
-  !!  SOURCE
-  !!
-  subroutine get_xc_potential_LDA_PW92(density, xc_potential,       &
-                                       xc_epsilon, xc_energy_total, &
-                                       size, x_epsilon, c_epsilon)
-
-    use datatypes
-    use numbers
-    use GenComms, only: gsum
-    use dimens,   only: grid_point_volume, n_my_grid_points
-
-    implicit none
-
-    ! Passed variables
-    integer,                    intent(in)  :: size
-    real(double),               intent(out) :: xc_energy_total
-    real(double), dimension(:), intent(in)  :: density
-    real(double), dimension(:), intent(out) :: xc_epsilon, xc_potential
-    ! optional
-    real(double), dimension(:), intent(out), optional :: x_epsilon, c_epsilon
-
-    ! Local variables
-    integer      :: n
-    real(double) :: prefactor, postfactor, denominator, &
-                    e_correlation, e_exchange,          &
-                    rcp_rs, rho, rs, sq_rs,             &
-                    v_correlation, v_exchange,          &
-                    delta_prefactor, delta_postfactor
-
-
-    ! From Table I, Phys. Rev. B 45, 13244 (1992), for reference
-    real(double), parameter :: alpha  = 1.0421234_double
-    real(double), parameter :: alpha1 = 0.21370_double
-    real(double), parameter :: beta1  = 7.5957_double
-    real(double), parameter :: beta2  = 3.5876_double
-    real(double), parameter :: beta3  = 1.6382_double
-    real(double), parameter :: beta4  = 0.49294_double
-    real(double), parameter :: A      = 0.031091_double
-
-    ! Precalculated constants
-    real(double), parameter :: k00 = 1.611991954_double     ! (4*pi/3)**(1/3)
-    real(double), parameter :: k01 = -0.458165347_double    ! -3/(2*pi*alpha)
-    real(double), parameter :: k02 = -0.062182_double       ! -2*A
-    real(double), parameter :: k03 = -0.0132882934_double   ! -2*A*alpha1
-    real(double), parameter :: k04 = 0.4723158174_double    ! 2*A*beta1
-    real(double), parameter :: k05 = 0.2230841432_double    ! 2*A*beta2
-    real(double), parameter :: k06 = 0.1018665524_double    ! 2*A*beta3
-    real(double), parameter :: k07 = 0.03065199508_double   ! 2*A*beta4
-    real(double), parameter :: k08 = -0.008858862267_double ! 2*k03/3
-    real(double), parameter :: k09 = 0.0787193029_double    ! k04/6
-    real(double), parameter :: k10 = 0.074361381067_double  ! k05/3
-    real(double), parameter :: k11 = 0.0509332762_double    ! k06/2
-    real(double), parameter :: k12 = 0.0204346633867_double ! 2*k07/3
-
-    xc_energy_total = zero
-    if (present(x_epsilon)) x_epsilon = zero
-    if (present(c_epsilon)) c_epsilon = zero
-
-    do n = 1, n_my_grid_points ! loop over grid pts and store potl on each
-       rho = spin_factor * density(n)  ! DRB Added to correct for lack of spin 2018/06/11
-
-       if (rho > RD_ERR) then ! Find radius of hole
-          rcp_rs = k00 * ( rho**third )
-       else
-          rcp_rs = zero
-       end if
-
-       ! ENERGY
-
-       ! Exchange
-       e_exchange = k01 * rcp_rs
-       if (present(x_epsilon)) x_epsilon(n) = e_exchange
-
-       ! Correlation
-       if (rcp_rs > zero) then
-          rs = one/rcp_rs
-       else
-          rs = zero
-       end if
-       sq_rs = sqrt(rs)
-
-       prefactor = k02 + k03*rs
-       denominator = sq_rs * ( k04 + sq_rs * ( k05 + sq_rs * ( k06 + k07 * sq_rs)))
-       if (denominator > zero) then
-          postfactor = log( one + one/denominator )
-       else
-          postfactor = 0
-       end if
-
-       e_correlation = prefactor * postfactor
-       if (present(c_epsilon)) c_epsilon(n) = e_correlation
-
-       ! Both exchange and correlation
-
-       xc_epsilon(n)   = e_exchange + e_correlation
-       xc_energy_total = xc_energy_total + xc_epsilon(n)*rho
-
-       ! POTENTIAL
-
-       ! Exchange
-
-       v_exchange = four_thirds * e_exchange
-
-       ! Correlation
-       !   (derivative of rho * e_correlation)
-
-       ! NOTE: delta_prefactor is actually the derivative of rho*prefactor
-       !       delta_postfactor is rho times the derivative of postfactor
-       delta_prefactor  = k02 + k08*rs
-       if (sq_rs > zero) then
-          delta_postfactor = &
-               sq_rs * (k09 + sq_rs*(k10 + sq_rs*(k11 + k12 * sq_rs))) / &
-                       (denominator * (1 + denominator))
-       else
-          delta_postfactor = 0
-       end if
-
-       v_correlation = delta_prefactor * postfactor + prefactor * delta_postfactor
-
-       xc_potential(n) = v_exchange + v_correlation
-
-
-    end do ! do n_my_grid_points
-    call gsum(xc_energy_total)
-    ! and 'integrate' the energy over the volume of the grid point
-    xc_energy_total = xc_energy_total * grid_point_volume
-
-    return
-  end subroutine get_xc_potential_LDA_PW92
-  !!***
-
-
-  !!****f* XC_modue/Vxc_of_r_LSDA_PW92 *
+  !!****f* XC_module/Vxc_of_r_LSDA_PW92 *
   !! PURPOSE
   !!   Calculates the exchange-correlation energy density and
   !!   potential as a function of rho(r) (evaluated at single grid
@@ -2578,484 +2546,548 @@ contains
   end subroutine get_xc_potential_hyb_PBE0
   !!*****
 
-
-  !!****f* XC_module/get_xc_potential_GGA_PBE_obsolete *
+  !!****f* XC/get_xc_energy *
   !!
   !!  NAME
-  !!   get_xc_potential_GGA_PBE_obsolete
+  !!   get_xc_energy
   !!  USAGE
   !!
   !!  PURPOSE
-  !!   Calculates the exchange-correlation potential
-  !!   on the grid within GGA using the
-  !!   Perdew-Burke-Ernzerhof. It also calculates the
-  !!   total exchange-correlation energy.
+  !!   Interface to CQ routines
+  !!  INPUTS
   !!
-  !!   Note that this is the functional described in
-  !!   Phys. Rev. Lett. 77, 3865 (1996)
+  !!  USES
   !!
-  !!   It is also (depending on an optional parameter)
-  !!     either revPBE, Phys. Rev. Lett. 80, 890 (1998),
-  !!     or RPBE, Phys. Rev. B 59, 7413 (1999)
+  !!  AUTHOR
+  !!   D. R. Bowler
+  !!  CREATION DATE
+  !!   2021/07/22
+  !!  MODIFICATION HISTORY
+  !!  SOURCE
+  !!
+  subroutine get_xc_energy(density, xc_energy, size)
+
+    use datatypes
+    use numbers
+    use global_module,               only: exx_niter, exx_siter, exx_alpha, nspin
+
+    implicit none
+
+    ! Passed variables
+    integer                    :: size
+    real(double)               :: xc_energy
+    real(double), dimension(size,nspin) :: density
+
+    ! Local variables
+    real(double) :: loc_x_energy, exx_tmp
+
+    if(flag_use_libxc) then
+       call get_libxc_energy(density, xc_energy, size)
+    else
+       select case(flag_functional_type)
+       case (functional_lda_pz81)
+          ! NOT SPIN POLARISED
+          call get_xc_energy_LDA_PZ81(density(:,1), xc_energy, size)
+          !
+          !
+       case (functional_lda_gth96)
+          ! NOT SPIN POLARISED
+          call get_GTH_xc_energy(density(:,1), xc_energy, size)
+          !
+          !
+       case (functional_lda_pw92)
+          call get_xc_energy_LSDA_PW92(density, xc_energy, size)
+          !
+          !
+       case (functional_gga_pbe96)
+          call get_xc_energy_GGA_PBE(density, xc_energy, size)
+          !
+          !
+       case (functional_gga_pbe96_rev98)
+          call get_xc_energy_GGA_PBE(density, xc_energy, size, functional_gga_pbe96_rev98 )
+          !
+          !
+       case (functional_gga_pbe96_r99)
+          call get_xc_energy_GGA_PBE(density, xc_energy, size, functional_gga_pbe96_r99 )
+          !
+          !
+       case (functional_gga_pbe96_wc)
+          call get_xc_energy_GGA_PBE(density, xc_energy, size, functional_gga_pbe96_wc )
+          !
+          !
+       case (functional_hyb_pbe0)
+          !
+          if ( exx_niter < exx_siter ) then
+             exx_tmp = one
+          else
+             exx_tmp = one - exx_alpha
+          end if
+          !
+          call get_xc_energy_hyb_PBE0(density, xc_energy, size, exx_tmp, functional_gga_pbe96 )
+          !
+          !
+       case (functional_hartree_fock)
+          ! **<lat>**
+          ! not optimal but experimental
+          if (exx_niter < exx_siter) then
+             ! for the first call of get_H_matrix using Hartree-Fock method
+             ! to get something not to much stupid ; use pure exchange functional
+             ! in near futur such as Xalpha
+             call get_xc_energy_LSDA_PW92(density, xc_energy, size)
+          else
+             xc_energy    = zero
+          end if
+          !
+          !
+       case default
+          call get_xc_energy_LSDA_PW92(density, xc_energy, size)
+          !
+          !
+       end select
+    end if
+    return
+  end subroutine get_xc_energy
+  !!***
+
+  !!****f* XC_module/get_xc_energy_LDA_PZ81 *
+  !!
+  !!  NAME
+  !!   get_xc_energy_LDA_PZ81
+  !!  USAGE
+  !!
+  !!  PURPOSE
+  !!   Calculates the exchange-correlation energy
+  !!   on the grid within LDA using the Ceperley-Alder
+  !!   interpolation formula. 
+  !!
+  !!   Note that this is the Perdew-Zunger parameterisation of the
+  !!   Ceperley-Alder results for a homogeneous electron gas, as
+  !!   described in Phys. Rev. B 23, 5048 (1981), with Ceperley-Alder in
+  !!   Phys. Rev. Lett. 45, 566 (1980)
+  !!       Exchange energy: It can be found in:
+  !!                        Phys. Rev. B 45, 13244 (1992)
+  !!                      **See Eq. 26
+  !!       Correlation energy: The correlation functional is PZ-81
+  !!                           Phys. Rev. B 23, 5048 (1981)
+  !!                         **See Appendix C, and specially Table XII,
+  !!                             Eq. C1 for the xc hole (rs),
+  !!                             Eqs. C3 & C4, for rs > 1 and
+  !!                             Eqs. C5 & C6, for rs < 1
   !!  INPUTS
   !!
   !!
   !!  USES
   !!
   !!  AUTHOR
-  !!   A.S. Torralba
+  !!   E.H.Hernandez/DRB
   !!  CREATION DATE
-  !!   11/11/05
+  !!   02/03/95 and 2021/07/22
   !!  MODIFICATION HISTORY
-  !!   17/07/06 rgradient(1,:) used for storage of final result, before transform,
-  !!            instead of direct transform of the sum
-  !!            rgradient(1,:) + rgradient(2,:) + rgradient(3,:)
-  !!          (this was less efficient)
-  !!   15:55, 27/04/2007 drb
-  !!     Changed recip_vector, grad_density to (n,3) for speed
-  !!   2008/11/13 ast
-  !!     Added revPBE and RPBE
-  !!   2011/12/12 L.Tong
-  !!     Removed third, it is now defined in numbers_module
-  !!   2012/04/11 L.Tong
-  !!     Added optional parameters x_epsilon and c_epsilon to output
-  !!     the exchange and correlation parts of xc_epsilon respectively.
-  !!   2017/08/29 jack baker & dave
-  !!     Removed rcellx references (redundant)
   !!  SOURCE
   !!
-  subroutine get_xc_potential_GGA_PBE_obsolete(density, xc_potential, &
-                                               xc_epsilon, xc_energy, &
-                                               size, flavour,         &
-                                               x_epsilon, c_epsilon)
+  subroutine get_xc_energy_LDA_PZ81(density, xc_energy, size)
 
     use datatypes
     use numbers
-    use dimens,        only: grid_point_volume, n_my_grid_points
-    use GenComms,      only: gsum, cq_abort
-    use fft_module,    only: fft3, recip_vector
+    use GenComms,               only: gsum
+    use dimens,                 only: grid_point_volume, n_my_grid_points
+
+    implicit none
+
+    ! Passed variables
+    integer,                    intent(in)  :: size
+    real(double),               intent(out) :: xc_energy
+    real(double), dimension(:), intent(in)  :: density
+
+    ! Local variables
+    integer      :: n
+    real(double) :: denominator, e_correlation, e_exchange, ln_rs, &
+                    numerator, rcp_rs, rho, rs, rs_ln_rs, sq_rs,   &
+                    v_correlation, v_exchange
+    real(double), parameter :: alpha  = -0.45817_double
+    real(double), parameter :: beta_1 =  1.0529_double
+    real(double), parameter :: beta_2 =  0.3334_double
+    real(double), parameter :: gamma  = -0.1423_double
+    real(double), parameter :: p =  0.0311_double
+    real(double), parameter :: q = -0.048_double
+    real(double), parameter :: r =  0.0020_double
+    real(double), parameter :: s = -0.0116_double
+
+    xc_energy = zero
+
+    do n = 1, n_my_grid_points ! loop over grid pts and store potl on each
+       rho = spin_factor * density(n)  ! DRB Added to correct for lack of spin 2018/06/11
+       if (rho > RD_ERR) then ! Find radius of hole
+          rcp_rs = ( four_thirds * pi * rho )**(third)
+       else
+          rcp_rs = zero
+       end if
+       e_exchange = alpha * rcp_rs
+       if (rcp_rs>zero) then
+          rs = one/rcp_rs
+       else
+          rs = zero
+       end if
+       sq_rs = sqrt(rs)
+       if (rs>=one) then
+          denominator = one / (one + beta_1 * sq_rs + beta_2 * rs)
+          numerator   = one + seven_sixths * beta_1 * sq_rs +  &
+               four_thirds * beta_2 * rs
+          e_correlation = gamma * denominator
+       else if ((rs<one).and.(rs>RD_ERR)) then
+          ln_rs    = log(rs)
+          rs_ln_rs = rs * ln_rs
+          e_correlation = p * ln_rs + q  + r * rs_ln_rs + s * rs
+       else
+          e_correlation = zero
+       end if
+       xc_energy       = xc_energy  + (e_exchange + e_correlation) * spin_factor * density(n)  ! DRB Added to correct for lack of spin 2018/06/11
+    end do ! do n_my_grid_points
+    call gsum(xc_energy)
+    ! and 'integrate' the energy over the volume of the grid point
+    xc_energy = xc_energy * grid_point_volume
+
+    return
+  end subroutine get_xc_energy_LDA_PZ81
+  !!***
+
+
+  !!****f* XC_module/get_GTH_xc_energy *
+  !!
+  !!  NAME
+  !!   get_xc_energy
+  !!  USAGE
+  !!
+  !!  PURPOSE
+  !!   Calculates the exchange-correlation energy
+  !!   on the grid within LDA using the Ceperley-Alder
+  !!   interpolation formula. It also calculates the
+  !!   total exchange-correlation energy.
+  !!
+  !!   Note that this is the Goedecker/Teter/Hutter formula which
+  !!   involves only ratios of polynomials, and is rather easy to
+  !!   differentiate.  See PRB 54, 1703 (1996)
+  !!  INPUTS
+  !!
+  !!
+  !!  USES
+  !!
+  !!  AUTHOR
+  !!   D.R.Bowler
+  !!  CREATION DATE
+  !!   14:45, 25/03/2003 and 2021/07/22 14:51 
+  !!  MODIFICATION HISTORY
+  !!  SOURCE
+  !!
+  subroutine get_GTH_xc_energy(density, xc_energy, size)
+
+    use datatypes
+    use numbers
+    use global_module,          only: io_lun
+    use GenComms,               only: cq_abort, gsum
+    use dimens,                 only: grid_point_volume, n_my_grid_points
 
     implicit none
 
     ! Passed variables
     integer,      intent(in)  :: size
-    real(double), intent(in)  :: density(size)
-    real(double), intent(out) :: xc_potential(size), xc_epsilon(size)
     real(double), intent(out) :: xc_energy
-    ! optional
-    integer,intent(in), optional :: flavour
-    real(double), dimension(size), optional, intent(out) :: x_epsilon, c_epsilon
+    real(double), dimension(:), intent(in)  :: density
 
-    !     Local variables
-    integer :: n
-    integer :: selector
-
-    real(double), allocatable, dimension(:)   :: grad_density
-    real(double), allocatable, dimension(:,:) :: grad_density_xyz
-    real(double), allocatable, dimension(:)   :: ex_lda, ec_lda
-    real(double) :: rho, grad_rho, rho1_3, rho1_6, ks, s, s2, t, t2,   &
-                    A, At2, factor0, factor1, factor2, factor3,        &
-                    factor4, denominator0, numerator1, denominator1,   &
-                    num_den1, numerator2, dt2_drho, dA_drho,           &
-                    dnumerator1_drho, ddenominator1_drho,              &
-                    dnumerator1_dt2, dnumerator1_dA,                   &
-                    ddenominator1_dt2, ddenominator1_dA, dfactor2_dt2, &
-                    dfactor2_dnumerator1, dfactor2_ddenominator1,      &
-                    dfactor2_drho, dfactor3_dfactor2, dfactor3_drho
-    real(double) :: xc_energy_lda_total,                               &
-                    e_correlation_lda,                                 &
-                    de_correlation_lda,                                &
-                    e_exchange, e_correlation,                         &
-                    de_exchange, de_correlation,                       &
-                    dde_exchange, dde_correlation
-    real(double) :: df_dgrad_rho
-    real(double) :: kappa, mu_kappa
-    real(double) :: rpbe_exp
-    ! Gradient in reciprocal space
-    complex(double_cplx), allocatable, dimension(:,:) :: rgradient
-
-    !     From Phys. Rev. Lett. 77, 3865 (1996)
-    real(double), parameter :: mu = 0.21951_double
-    real(double), parameter :: beta = 0.066725_double
-    real(double), parameter :: gamma = 0.031091_double
-    real(double), parameter :: kappa_ori = 0.804_double
-
-    !     From Phys. Rev. Lett. 80, 890 (1998)
-    real(double), parameter :: kappa_alt = 1.245_double
-
-    !     Precalculated constants
-    real(double), parameter :: mu_kappa_ori = 0.27302_double     ! mu/kappa_ori
-    real(double), parameter :: mu_kappa_alt = 0.17631_double     ! mu/kappa_alt
-    real(double), parameter :: two_mu = 0.43902_double           ! 2*mu
-    real(double), parameter :: beta_gamma = 2.146119_double      ! beta/gamma
-    real(double), parameter :: beta_X_gamma = 0.002074546_double ! beta*gamma
-    real(double), parameter :: k01 = 0.16162045967_double        ! 1/(2*(3*pi*pi)**(1/3))
-    real(double), parameter :: k02 = -0.16212105381_double       ! -3*mu*((4*pi/3)**(1/3))/(2*pi*alpha)
-                                                                 ! =mu*k00*k01(LDA_PW92)=mu*k04
-    real(double), parameter :: k03 = 1.98468639_double           ! ((4/pi)*(3*pi*pi)**(1/3))**(1/2)
-    real(double), parameter :: k04 = -0.738558852965_double      ! -3*((4*pi/3)**(1/3))/(2*pi*alpha) = k00*k01 in LDA_PW92
-    real(double), parameter :: k05 = 0.05240415_double           ! -2*k01*k02
-    real(double), parameter :: k06 = -0.593801317784_double      ! k04*kappa_ori
-    real(double), parameter :: k07 = -0.984745137287_double      ! 4*k04/3
-    real(double), parameter :: seven_thirds = 2.333333333_double ! 7/3
-
-    integer :: stat
-    !      Selector options
-    integer, parameter :: fx_original    = 1                     ! Used in PBE and revPBE
-    integer, parameter :: fx_alternative = 2                     ! Used in RPBE
-
-    ! Choose between PBE or revPBE parameters
-    if(PRESENT(flavour)) then
-      if(flavour==functional_gga_pbe96_rev98) then
-        kappa=kappa_alt
-        mu_kappa=mu_kappa_alt
-      else
-        kappa=kappa_ori
-        mu_kappa=mu_kappa_ori
-      end if
-    else
-      kappa=kappa_ori
-      mu_kappa=mu_kappa_ori
-    end if
-
-    if (present(x_epsilon)) then
-       allocate(ex_lda(size), STAT=stat)
-       if (stat /= 0) &
-            call cq_abort("Error allocating ex_lda for PBE functional: ", stat)
-    end if
-
-    if (present(c_epsilon)) then
-       allocate(ec_lda(size), STAT=stat)
-       if (stat /= 0) &
-            call cq_abort("Error allocating ec_lda for PBE functional ", stat)
-    end if
-
-    allocate(grad_density(size), grad_density_xyz(size,3),&
-             rgradient(size,3),STAT = stat)
-    !initialisation  2010.Oct.30 TM
-    grad_density(:) = zero
-    grad_density_xyz(:,:) = zero
-    rgradient(:,:) = zero
-    xc_epsilon(:) = zero
-    xc_potential(:) = zero
-    if (present(x_epsilon)) then
-       x_epsilon = zero
-       ex_lda = zero
-    end if
-    if (present(c_epsilon)) then
-       c_epsilon = zero
-       ec_lda = zero
-    end if
-    if (stat /= 0) &
-         call cq_abort("Error allocating arrays for PBE functional: ", stat)
-
-    ! Choose functional form
-    if (present(flavour)) then
-       if (flavour == functional_gga_pbe96_r99) then
-          selector = fx_alternative
-       else
-          selector = fx_original
-       end if
-    else
-       selector = fx_original
-    end if
-
-    ! Build the gradient of the density
-    call build_gradient(density, grad_density_xyz, size)
-
-    grad_density(:) = sqrt(grad_density_xyz(:,1)**2 + &
-                           grad_density_xyz(:,2)**2 + &
-                           grad_density_xyz(:,3)**2)
-
-    ! Get the LDA part of the functional
-    if (present(x_epsilon) .and. present(c_epsilon)) then
-       call get_xc_potential_LDA_PW92(density, xc_potential, xc_epsilon, &
-                                      xc_energy_lda_total, size,         &
-                                      x_epsilon=ex_lda,                  &
-                                      c_epsilon=ec_lda)
-    else if (present(x_epsilon)) then
-       call get_xc_potential_LDA_PW92(density, xc_potential, xc_epsilon, &
-                                      xc_energy_lda_total, size,         &
-                                      x_epsilon=ex_lda)
-    else if (present(c_epsilon)) then
-       call get_xc_potential_LDA_PW92(density, xc_potential, xc_epsilon, &
-                                      xc_energy_lda_total, size,         &
-                                      c_epsilon=ec_lda)
-    else
-       call get_xc_potential_LDA_PW92(density, xc_potential, xc_epsilon, &
-                                      xc_energy_lda_total, size)
-    end if
+    ! Local variables
+    integer n
+    real(double) :: denominator, e_correlation, e_exchange, ln_rs,    &
+                    numerator, rcp_rs, rho, rs, rs_ln_rs, sq_rs,      &
+                    v_correlation, v_exchange, drs_dRho, t1, t2, dt1, &
+                    dt2
+    real(double), parameter :: a0=0.4581652932831429_double
+    real(double), parameter :: a1=2.217058676663745_double
+    real(double), parameter :: a2=0.7405551735357053_double
+    real(double), parameter :: a3=0.01968227878617998_double
+    real(double), parameter :: b1=1.000000000000000_double
+    real(double), parameter :: b2=4.504130959426697_double
+    real(double), parameter :: b3=1.110667363742916_double
+    real(double), parameter :: b4=0.02359291751427506_double
 
     xc_energy = zero
     do n = 1, n_my_grid_points ! loop over grid pts and store potl on each
-       rho = density(n)
-       grad_rho = grad_density(n)
-
-       !!!!!!   XC GGA ENERGY
-
-       ! Exchange
-
-       if (rho > RD_ERR) then
-          rho1_3 = rho ** third
-          rho1_6 = sqrt (rho1_3)
-          s = k01 * grad_rho / (rho ** four_thirds)
-          s2 = s * s
-          if(selector == fx_alternative) then           ! RPBE
-            rpbe_exp = exp(-mu_kappa * s2)
-            e_exchange = k06*rho1_3*(1.0_double-rpbe_exp)
-          else                                          ! PBE, revPBE
-            denominator0 = 1.0 / (1.0 + mu_kappa * s2)
-            factor0 = k02 * rho1_3
-            factor1 = s2 * denominator0
-            ! NOTE: This doesn't look like in Phys. Rev. Lett. 77:18,
-            !       3865 (1996) because the 1 in Fx, has been
-            !       multiplied by Ex-LDA and is implicit in
-            !       xc_energy_lda(n), in the total energy below
-            e_exchange = factor0 * factor1
-          end if
+       rho = spin_factor * density(n)  ! DRB Added to correct for lack of spin 2018/06/11
+       if (rho > RD_ERR) then ! Find radius of hole
+          rcp_rs = ( four*third * pi * rho )**(third)
+          rs     = one/rcp_rs
        else
-          e_exchange = zero
+          rcp_rs = zero
+          rs     = zero
        end if
-
-       if (present(x_epsilon)) x_epsilon(n) = e_exchange + ex_lda(n)
-
-       ! Correlation
-
-       if (rho > RD_ERR) then
-          e_correlation_lda = xc_epsilon(n) - k04 * rho1_3
-
-          ! t=grad_rho/(2*rho*ks); ks=sqrt(4*kf/pi); kf=(3*pi*pi*rho)**(1/3); s=grad_rho/(2*rho*kf)
-          ks = k03 * rho1_6
-          t = grad_rho / ( 2 * ks * rho )
-          t2 = t * t
-
-          A = exp(-e_correlation_lda / gamma) - 1.0
-          if (A > RD_ERR) then
-             A = beta_gamma / A
-          else
-             A = beta_gamma * BIG
-          end if
-
-          At2 = A * t2
-          numerator1 = 1.0 + At2
-          denominator1 = 1.0 + At2 + At2 * At2
-          num_den1 = numerator1 / denominator1
-
-          factor2 = t2 * num_den1
-          factor3 = gamma * log(one + beta_gamma * factor2)
-
-          e_correlation = factor3;  !gamma * log( 1.0 + beta_gamma * t2 * num_den1 )
-       else
-          e_correlation = zero
+       if (rs > zero) then
+          drs_dRho = -rs / (3.0 * rho)
+          t1  = a0 + rs*(a1 + rs * (a2 + rs * a3))
+          t2  = rs * (b1 + rs * (b2 + rs * (b3 + rs * b4)))
+          dt1 = a1 + rs * (2.0 * a2 + rs * 3.0 * a3)
+          dt2 = b1 + rs * (2.0 * b2 + rs * (3.0 * b3 + rs * 4.0 * b4))
+          xc_energy = xc_energy - (t1/t2)*rho
        end if
-
-       if (present(c_epsilon)) c_epsilon(n) = e_correlation + ec_lda(n)
-
-       !*ast* TEST-POINT 1
-       ! Both exchange and correlation
-       xc_energy = xc_energy + (xc_epsilon(n) + e_exchange + e_correlation)*rho
-       ! Only LDA part
-       !xc_energy = xc_energy + (xc_epsilon(n))*rho
-       ! LDA + exchange
-       !xc_energy = xc_energy + (xc_epsilon(n) + e_exchange)*rho
-       ! Only exchange
-       !xc_energy = xc_energy + (e_exchange)*rho
-       ! LDA + correlation
-       !xc_energy = xc_energy + (xc_epsilon(n) + e_correlation)*rho
-       ! Only correlation
-       !xc_energy = xc_energy + (e_correlation)*rho
-
-       !!!!!!   POTENTIAL
-
-       !!!   Terms due to df/drho
-
-       ! Exchange
-
-       if (rho > RD_ERR) then
-          if(selector == fx_alternative) then           ! RPBE
-            de_exchange = k07 * rho1_3 * (kappa - (two_mu * s2 + kappa) * rpbe_exp)
-          else                                          ! PBE, revPBE
-            de_exchange = four_thirds * factor0 * factor1 * ( 1 - 2* denominator0 )
-          end if
-       else
-          de_exchange = zero
-       end if
-
-       ! Correlation
-
-       if (rho > RD_ERR) then
-          de_correlation_lda = ( xc_potential(n) &
-                               - four_thirds * k04 * rho1_3 &
-                               - e_correlation_lda ) / rho
-
-          dt2_drho = -seven_thirds * t2 / rho
-          dA_drho  = A * A * exp(-e_correlation_lda / gamma ) * de_correlation_lda / beta
-          dnumerator1_dt2   = A
-          dnumerator1_dA    = t2
-          factor4 = 1.0 + 2 * At2
-          ddenominator1_dt2 = A * factor4
-          ddenominator1_dA  = t2 * factor4
-          dnumerator1_drho   = dnumerator1_dt2 * dt2_drho &
-                             + dnumerator1_dA * dA_drho
-          ddenominator1_drho = ddenominator1_dt2 * dt2_drho &
-                             + ddenominator1_dA * dA_drho
-          dfactor2_dt2 = num_den1
-          dfactor2_dnumerator1   = t2 / denominator1
-          dfactor2_ddenominator1 = -factor2 / denominator1
-          dfactor2_drho = dfactor2_dt2 * dt2_drho &
-                        + dfactor2_dnumerator1 * dnumerator1_drho &
-                        + dfactor2_ddenominator1 * ddenominator1_drho
-          dfactor3_dfactor2 = beta / ( 1.0 + beta_gamma * factor2 )
-          dfactor3_drho = dfactor3_dfactor2 * dfactor2_drho
-          de_correlation = factor3 + rho * dfactor3_drho
-       else
-          de_correlation = zero
-       end if
-
-       !*ast* TEST-POINT 2
-       xc_potential(n) = xc_potential(n) + de_exchange + de_correlation
-       ! Only LDA part
-       !xc_potential(n) = xc_potential(n)
-       ! LDA + exchange
-       !xc_potential(n) = xc_potential(n) + de_exchange
-       ! Only exchange
-       !xc_potential(n) = de_exchange
-       ! LDA + correlation
-       !xc_potential(n) = xc_potential(n) + de_correlation
-       ! Only correlation
-       !xc_potential(n) = de_correlation
-
-       !!!   Terms due to df/d|grad_rho|
-
-       ! Exchange
-
-       if (rho > RD_ERR) then
-          if(selector == fx_alternative) then           ! RPBE
-             dde_exchange = -k05 * s * rpbe_exp
-          else                                          ! PBE, revPBE
-             dde_exchange = -k05 * s * denominator0 * denominator0!factor1 * denominator0
-          end if
-       else
-          dde_exchange = zero
-       end if
-
-       ! Correlation
-
-       if (rho > RD_ERR) then
-          numerator2 = beta_X_gamma * t * ( 1.0 + 2.0 * At2 ) &
-                     / (( gamma * denominator1 + beta * t2 * numerator1 ) * denominator1)
-          dde_correlation = numerator2 / ks;
-       else
-          dde_correlation = zero
-       end if
-
-       ! Normalisation (modulus of gradient)
-
-       !*ast* TEST-POINT 3
-       if(abs(grad_density(n)) > RD_ERR) then  !DEBUG
-       df_dgrad_rho = (dde_exchange + dde_correlation) / grad_density(n)
-       else                 !DEBUG
-       df_dgrad_rho = zero   !DEBUG
-       endif                !DEBUG
-       ! Only LDA part
-       !df_dgrad_rho = 0.0
-       ! LDA + exchange
-       !df_dgrad_rho = dde_exchange / grad_density(n)
-       ! Only exchange
-       !df_dgrad_rho = dde_exchange / grad_density(n)
-       ! LDA + correlation
-       !df_dgrad_rho = dde_correlation / grad_density(n)
-       ! Only correlation
-       !df_dgrad_rho = dde_correlation / grad_density(n)
-
-
-       ! Gradient times derivative of energy
-
-       grad_density_xyz(n,1) = grad_density_xyz(n,1)*df_dgrad_rho
-       grad_density_xyz(n,2) = grad_density_xyz(n,2)*df_dgrad_rho
-       grad_density_xyz(n,3) = grad_density_xyz(n,3)*df_dgrad_rho
-
-       !xc_epsilon  !2010.Oct.30 TM
-       xc_epsilon(n) = xc_epsilon(n) + e_exchange + e_correlation
-       !*ast* TEST-POINT 4
-       !TM delta_E_xc = delta_E_xc + (xc_epsilon(n) + e_exchange + e_correlation)*rho
-       ! Only LDA part
-       !delta_E_xc = delta_E_xc + (xc_epsilon(n))*rho
-       ! LDA + exchange
-       !delta_E_xc = delta_E_xc + (xc_epsilon(n) + e_exchange)*rho
-       ! Only exchange
-       !delta_E_xc = delta_E_xc + (e_exchange)*rho
-       ! LDA + correlation
-       !delta_E_xc = delta_E_xc + (xc_epsilon(n) + e_correlation)*rho
-       ! Only correlation
-       !delta_E_xc = delta_E_xc + (e_correlation)*rho
-
     end do ! do n_my_grid_points
-
-
-    !!!   Final steps of the energy calculation
-
-    ! Add the energies and 'integrate' over the volume of the grid points
-
     call gsum(xc_energy)
+    ! and 'integrate' the energy over the volume of the grid point
     xc_energy = xc_energy * grid_point_volume
-
-    ! Fourier transform the gradient, component by component
-
-    call fft3(grad_density_xyz(:,1), rgradient(:,1), size, -1 )
-    call fft3(grad_density_xyz(:,2), rgradient(:,2), size, -1 )
-    call fft3(grad_density_xyz(:,3), rgradient(:,3), size, -1 )
-
-    !!!   Get the second term of the potential by taking derivatives
-
-    ! First, get the scalar product of the (normalised) gradient and the wave vector (times i)
-
-    rgradient(:,1) = -rgradient(:,1)*minus_i*recip_vector(:,1)
-    rgradient(:,1) = rgradient(:,1) - rgradient(:,2)*minus_i*recip_vector(:,2)
-    rgradient(:,1) = rgradient(:,1) - rgradient(:,3)*minus_i*recip_vector(:,3)
-
-    ! Add terms of the scalar product and then Fourier transform back the resultant vector
-    ! NOTE: Store the result in the modulus of the gradient (not needed anymore) to save memory
-
-    call fft3( grad_density, rgradient(:,1), size, 1 )
-
-    ! Finally, get the potential
-    ! NOTE that here grad_density is NOT the modulus of the gradient,
-    !      but a term of the potential (see Fourier transform above)
-
-    do n=1,n_my_grid_points
-        xc_potential(n) = xc_potential(n) - grad_density(n)
-    end do
-
-    ! I changed the order of deallocation, because I was told that deallocation
-    ! of the latest allocated array should be done first.
-    ! (though I am not sure whether it is true or not)   2010.Oct.30 TM
-
-    if(allocated(rgradient)) then
-       deallocate(rgradient,STAT=stat)
-       if(stat/=0) call cq_abort("Error deallocating rgradient",stat)
-    end if
-    if(allocated(grad_density_xyz)) then
-       deallocate(grad_density_xyz,STAT=stat)
-       if(stat/=0) call cq_abort("Error deallocating grad_density_xyz",stat)
-    end if
-    if(allocated(grad_density)) then
-       deallocate(grad_density,STAT=stat)
-       if(stat/=0) call cq_abort("Error deallocating grad_density",stat)
-    end if
-    if (allocated(ex_lda)) then
-       deallocate(ex_lda,STAT=stat)
-       if (stat /= 0) call cq_abort("Error deallocating ex_lda", stat)
-    end if
-    if (allocated(ec_lda)) then
-       deallocate(ec_lda,STAT=stat)
-       if (stat /= 0) call cq_abort("Error deallocating ec_lda", stat)
-    end if
-
     return
-  end subroutine get_xc_potential_GGA_PBE_obsolete
+  end subroutine get_GTH_xc_energy
   !!***
 
+  !!****f* XC_module/get_xc_energy_LSDA_PW92 *
+  !!
+  !!  NAME
+  !!   get_xc_energy_LSDA_PW92
+  !!  USAGE
+  !!
+  !!  PURPOSE
+  !!   Calculates the spin polarized exchange-correlation
+  !!   energy on the grid within LDA using the Ceperley-Alder
+  !!   interpolation formula. It also calculates the total
+  !!   exchange-correlation energy.
+  !!
+  !!   Note that this is the Perdew-Wang parameterisation of the
+  !!   Ceperley-Alder results for a homogeneous electron gas, as
+  !!   described in Phys. Rev. B 45, 13244 (1992), with Ceperley-Alder
+  !!   in Phys. Rev. Lett. 45, 566 (1980) INPUTS
+  !!
+  !!  USES
+  !!
+  !!  AUTHOR
+  !!   L. Tong and DRB
+  !!  CREATION DATE
+  !!   22/03/2011 and 2021/07/22 14:52
+  !!  MODIFICATION HISTORY
+  !!  SOURCE
+  !!
+  subroutine get_xc_energy_LSDA_PW92(density, xc_energy_total, size)
+
+    use datatypes
+    use numbers
+    use GenComms,               only: cq_abort, gsum
+    use dimens,                 only: grid_point_volume, n_my_grid_points
+    use global_module,          only: nspin
+
+    implicit none
+
+    ! Passed variables
+    ! size of the real space grid
+    integer,                      intent(in)  :: size
+    real(double),                 intent(out) :: xc_energy_total
+    real(double), dimension(:,:), intent(in)  :: density
+
+    ! Local variables
+    integer      :: rr, spin
+    real(double) :: eps_x, eps_c, rho_tot_r
+    real(double), dimension(nspin) :: rho_r, Vx, Vc
+
+    ! initialisation
+    xc_energy_total = zero
+
+    ! loop over grid points on each node
+    do rr = 1, n_my_grid_points
+       rho_r(1:nspin) = density(rr,1:nspin)
+       rho_tot_r      = rho_r(1) + rho_r(nspin)
+       call Vxc_of_r_LSDA_PW92(nspin, rho_r, eps_x=eps_x, eps_c=eps_c,&
+                               Vx=Vx, Vc=Vc)
+
+       xc_energy_total = xc_energy_total + (eps_x + eps_c)  * rho_tot_r
+    end do
+    call gsum(xc_energy_total)
+    xc_energy_total = xc_energy_total * grid_point_volume
+    return
+  end subroutine get_xc_energy_LSDA_PW92
+  !!***
+
+  !!****f* XC_module/get_xc_energy_GGA_PBE
+  !! PURPOSE
+  !!   Calculates the exchange-correlation energy
+  !!   on the grid within GGA using three flavours of
+  !!   Perdew-Burke-Ernzerhof. It also calculates the
+  !!   total exchange-correlation energy.
+  !!
+  !!   flavour not defined
+  !!     use original PBE, PRL 77, 3865 (1996)
+  !!   flavour = functional_gga_pbe96_rev98:
+  !!     use revPBE, PRL 80, 890 (1998)
+  !!   flavour = functional_gga_pbe96_r99:
+  !!     use RPBE, PRB 59, 7413 (1999)
+  !!
+  !! USAGE
+  !!   call get_xc_energy_GGA_PBE(density, xc_potential,      &
+  !!                                 xc_epsilon, xc_energy, size,&
+  !!                                 flavour)
+  !! INPUTS
+  !!   integer      size                : size of the real space grid
+  !!   integer      flavour             : flavour of PBE functional (optional)
+  !!   real(double) density(size,nspin) : spin dependent density
+  !! OUTPUT
+  !!   real(double) xc_energy                : total xc-energy (sum over spin)
+  !!   real(double) xc_epsilon(size)         : xc-energy density
+  !!   real(double) xc_potential(size,nspin) : xc-potnetial
+  !! AUTHOR
+  !!   L.Tong and DRB
+  !! CREATION DATE 
+  !!   2012/04/27 and 2021/07/22 14:54 dave
+  !! MODIFICATION HISTORY
+  !! SOURCE
+  !!
+  subroutine get_xc_energy_GGA_PBE(density, xc_energy, grid_size, flavour)
+
+    use datatypes
+    use numbers
+    use global_module, only: nspin, flag_stress, flag_full_stress
+    use dimens,        only: grid_point_volume, n_my_grid_points
+    use GenComms,      only: gsum, cq_abort
+    use fft_module,    only: fft3, recip_vector
+    use memory_module, only: reg_alloc_mem, reg_dealloc_mem, type_dbl
+
+    implicit none
+
+    ! passed variables
+    integer,                      intent(in)  :: grid_size
+    real(double), dimension(:,:), intent(in)  :: density
+    real(double),                 intent(out) :: xc_energy
+    integer,      optional,       intent(in)  :: flavour
+
+    ! local variables
+    integer      :: PBE_type
+    integer      :: rr, spin, stat, dir1, dir2
+    real(double) :: eps_x, eps_c, rho_tot_r
+    real(double),         dimension(nspin)        :: rho_r
+    real(double),         dimension(3,nspin)      :: grho_r
+    real(double),         dimension(:,:,:), allocatable :: grad_density
+
+    allocate(grad_density(grid_size,3,nspin), STAT=stat)
+    if (stat /= 0) call cq_abort("get_xc_potential_GGA_PBE: Error alloc mem: ", grid_size)
+    call reg_alloc_mem(area_ops, grid_size*3*nspin, type_dbl)
+
+    if (present(flavour)) then
+       PBE_type = flavour
+    else
+       PBE_type = functional_gga_pbe96
+    end if
+
+    ! initialisation
+    grad_density = zero
+    xc_energy    = zero
+
+    ! Build the gradient of the density
+    do spin = 1, nspin
+       call build_gradient(density(:,spin), grad_density(:,:,spin), grid_size)
+    end do
+
+    do rr = 1, n_my_grid_points
+       rho_tot_r = density(rr,1) + density(rr,nspin)
+       do spin = 1, nspin
+          rho_r(spin)      = density(rr,spin)
+          grho_r(1:3,spin) = grad_density(rr,1:3,spin)
+       end do
+       call eps_xc_of_r_GGA_PBE(nspin, PBE_type, rho_r, grho_r, &
+                                eps_x=eps_x, eps_c=eps_c)
+       xc_energy      = xc_energy + rho_tot_r * (eps_x + eps_c)
+    end do ! rr
+    call gsum(xc_energy)
+    xc_energy = xc_energy * grid_point_volume
+    deallocate(grad_density, STAT=stat)
+    if (stat /= 0) call cq_abort("get_xc_potential_GGA_PBE: Error dealloc mem")
+    call reg_dealloc_mem(area_ops, grid_size*3*nspin, type_dbl)
+
+  end subroutine get_xc_energy_GGA_PBE
+  !!*****
+
+
+  !!****f* XC_module/get_xc_energy_hyb_PBE0
+  !! PURPOSE
+  !!
+  !!   Work routine based on get_xc_energy_GGA_PBE.
+  !!   It will be recoded in near futur to handle any hybrid functional.
+  !!   For now just handle one coefficient as in PBE0.
+  !! USAGE
+  !!
+  !! INPUTS
+  !!
+  !!   integer      size                : size of the real space grid
+  !!   integer      flavour             : flavour of PBE functional (optional)
+  !!   real(double) density(size,nspin) : spin dependent density
+  !! OUTPUT
+  !!   real(double) xc_energy                : total xc-energy (sum over spin)
+  !!
+  !! AUTHOR
+  !!   L.Tong/L.Truflandier/DRB
+  !! CREATION DATE
+  !!   2014/09/24 and 2021/07/22 15:00 dave
+  !! MODIFICATION HISTORY
+  !! SOURCE
+  !!
+  subroutine get_xc_energy_hyb_PBE0(density, xc_energy, grid_size, exx_a, flavour )
+    use datatypes
+    use numbers
+    use global_module, only: nspin, flag_full_stress, flag_stress
+    use dimens,        only: grid_point_volume, n_my_grid_points
+    use GenComms,      only: gsum, cq_abort
+    use fft_module,    only: fft3, recip_vector
+    use memory_module, only: reg_alloc_mem, reg_dealloc_mem, type_dbl
+
+    implicit none
+
+    ! passed variables
+    integer,                      intent(in)  :: grid_size
+    real(double), dimension(:,:), intent(in)  :: density
+    real(double),                 intent(out) :: xc_energy
+    integer,      optional,       intent(in)  :: flavour
+    real(double),                 intent(in)  :: exx_a
+
+    ! local variables
+    integer      :: PBE_type
+    integer      :: rr, spin, stat, dir1, dir2
+    real(double) :: eps_x, eps_c, rho_tot_r
+    real(double),         dimension(nspin)        :: rho_r
+    real(double),         dimension(3,nspin)      :: grho_r
+    real(double),         dimension(:,:,:), allocatable :: grad_density
+
+    allocate(grad_density(grid_size,3,nspin), STAT=stat)
+    if (stat /= 0) call cq_abort("get_xc_potential_GGA_PBE: Error alloc mem: ", grid_size)
+    call reg_alloc_mem(area_ops, grid_size*3*nspin, type_dbl)
+
+    if (present(flavour)) then
+       PBE_type = flavour
+    else
+       PBE_type = functional_gga_pbe96
+    end if
+
+    ! setup exx_a
+
+    ! Initialisation
+    grad_density = zero
+    xc_energy    = zero
+
+    ! Build the gradient of the density
+    do spin = 1, nspin
+       call build_gradient(density(:,spin), grad_density(:,:,spin), grid_size)
+    end do
+
+    do rr = 1, n_my_grid_points
+       rho_tot_r = density(rr,1) + density(rr,nspin)
+       do spin = 1, nspin
+          rho_r(spin)      = density(rr,spin)
+          grho_r(1:3,spin) = grad_density(rr,1:3,spin)
+       end do
+       call eps_xc_of_r_GGA_PBE(nspin, PBE_type, rho_r, grho_r, &
+                                eps_x    =eps_x, &
+                                eps_c    =eps_c)
+       xc_energy      = xc_energy + rho_tot_r * (exx_a * eps_x + eps_c)
+    end do ! rr
+    call gsum(xc_energy)
+    xc_energy = xc_energy * grid_point_volume
+    deallocate(grad_density, STAT=stat)
+    if (stat /= 0) call cq_abort("get_xc_potential_GGA_PBE: Error dealloc mem")
+    call reg_dealloc_mem(area_ops, grid_size*3*nspin, type_dbl)
+
+    return
+  end subroutine get_xc_energy_hyb_PBE0
+  !!*****
 
   !!****f* XC_module/build_gradient *
   !!

--- a/src/energy_module.f90
+++ b/src/energy_module.f90
@@ -137,6 +137,9 @@ contains
   !!   2021/07/26 11:13 dave
   !!    Removed output of hartree_energy_drho_atom_rho (now included
   !!    in delta_E_hartree)
+  !!   2021/07/28 10:55 dave
+  !!    Change behaviour to print Harris etc always, and DFT only if
+  !!    printDFT = T
   !!  SOURCE
   !!
   subroutine get_energy(total_energy, printDFT, level)
@@ -181,15 +184,6 @@ contains
     real(double), dimension(nspin) :: electrons
     real(double) :: electrons_tot
 
-    ! For Now,
-    ! If printDFT does not exist (as in the previous version),
-    !  DFT energy will be printed out if iprint_gen >= 2
-    !
-    ! If it exists,
-    !  printDFT = .true.  -> prints out only DFT energy
-    !  printDFT = .false. -> prints out Energies except DFT energy
-    !
-
 !****lat<$
     if (       present(level) ) backtrace_level = level+1
     if ( .not. present(level) ) backtrace_level = -10
@@ -200,7 +194,6 @@ contains
     print_DFT    = .false.
     print_Harris = .true.
     if (present(printDFT)) then
-       if (printDFT)     print_Harris = .false.
        print_DFT = printDFT
     else
        if (iprint_gen >= 2) print_DFT = .true.

--- a/src/energy_module.f90
+++ b/src/energy_module.f90
@@ -42,6 +42,8 @@
 !!   2021/07/23 16:46 dave
 !!    Changes to make the DFT energy correct, in particular creating hartree_energy_drho_input which
 !!    stores the value of hartree_energy_drho made from the input charge density when we have check_DFT T
+!!   2021/07/30 12:15 dave
+!!    Remove check_DFT
 !!  SOURCE
 !!
 module energy
@@ -78,8 +80,6 @@ module energy
   real(double) :: hartree_energy_drho_atom_rho ! Energy for rho_atom in drho potential
   real(double) :: screened_ion_interaction_energy
   
-  logical :: flag_check_DFT = .false.
-
   ! To avoid cyclic dependancy with DiagModule, the local variables here record information needed
   ! from DiagModule
   logical :: flag_check_Diag = .false.

--- a/src/energy_module.f90
+++ b/src/energy_module.f90
@@ -134,6 +134,9 @@ contains
   !!    Tidying up output for neutral atom
   !!   2018/05/24 19:00 nakata
   !!    Changed matKE, matNL and matNA to be spin_SF dependent
+  !!   2021/07/26 11:13 dave
+  !!    Removed output of hartree_energy_drho_atom_rho (now included
+  !!    in delta_E_hartree)
   !!  SOURCE
   !!
   subroutine get_energy(total_energy, printDFT, level)
@@ -263,7 +266,7 @@ contains
              if(flag_neutral_atom) then
                 write (io_lun, 1) en_conv*band_energy,     en_units(energy_units)
                 write (io_lun,33) en_conv*hartree_energy_drho,  en_units(energy_units)
-                write (io_lun,36) en_conv*hartree_energy_drho_atom_rho,  en_units(energy_units)
+                !write (io_lun,36) en_conv*hartree_energy_drho_atom_rho,  en_units(energy_units)
                 write (io_lun, 4) en_conv*(xc_energy+exx_energy), en_units(energy_units)
                 write (io_lun,23) en_conv*x_energy,               en_units(energy_units)
                 write (io_lun,24) en_conv*(xc_energy-x_energy),   en_units(energy_units)
@@ -272,7 +275,7 @@ contains
                 write (io_lun, 7) en_conv*nl_energy,       en_units(energy_units)
                 write (io_lun, 8) en_conv*kinetic_energy,  en_units(energy_units)
                 write (io_lun,39) en_conv*screened_ion_interaction_energy,    en_units(energy_units)
-                write (io_lun,11) en_conv*( -hartree_energy_drho), en_units(energy_units)
+                write (io_lun,11) en_conv*delta_E_hartree, en_units(energy_units)
                 write (io_lun,12) en_conv*delta_E_xc,      en_units(energy_units)
              else
                 write (io_lun, 1) en_conv*band_energy,     en_units(energy_units)
@@ -409,7 +412,7 @@ contains
 24  format(10x,'C only  Energy                   : ',f25.15,' ',a2)
 33  format(10x,'Hartree Energy (delta rho)       : ',f25.15,' ',a2)
 35  format(10x,'Neutral Atom  Energy             : ',f25.15,' ',a2)
-36  format(10x,'Hartree Energy (drho-atom rho)   : ',f25.15,' ',a2)
+!36  format(10x,'Hartree Energy (drho-atom rho)   : ',f25.15,' ',a2)
 39  format(10x,'Screened Ion-Ion Energy          : ',f25.15,' ',a2)
 
   end subroutine get_energy
@@ -582,7 +585,7 @@ contains
           !
           write (io_lun, 6) en_conv *    band_energy,  en_units(energy_units)
           if(flag_neutral_atom) then
-             write (io_lun,67) en_conv * hartree_energy_drho_input,  en_units(energy_units)
+             write (io_lun,67) en_conv * hartree_energy_drho,  en_units(energy_units)
              write (io_lun,68) en_conv * screened_ion_interaction_energy,  en_units(energy_units)
           else
              write (io_lun, 7) en_conv * hartree_energy_total_rho,  en_units(energy_units)

--- a/src/initial_read_module.f90
+++ b/src/initial_read_module.f90
@@ -865,7 +865,6 @@ contains
          flag_MatrixFile_BinaryFormat_Dump_END
 
     use group_module,     only: part_method, HILBERT, PYTHON
-    use energy,           only: flag_check_DFT
     use H_matrix_module,  only: locps_output, locps_choice
     use pao_minimisation, only: InitStep_paomin
     use timer_module,     only: time_threshold,lun_tmr, TimingOn, &
@@ -1761,7 +1760,6 @@ contains
        UseGemm = .false.
     endif
 
-    flag_check_DFT     = fdf_boolean('General.CheckDFT',.true.)
     flag_quench_MD     = fdf_boolean('AtomMove.QuenchMD',.false.)
     flag_fire_qMD = fdf_boolean('AtomMove.FIRE',.false.)
     ! If we're doing MD, then the centre of mass should generally be fixed,

--- a/src/minimise.f90
+++ b/src/minimise.f90
@@ -121,6 +121,8 @@ contains
   !!   2020/08/24 11:15 dave
   !!    Test implementation for performing LFD at each SCF step alongside
   !!    full SCF for each LFD
+  !!   2021/07/30 10:20 dave
+  !!    Remove extraneous get_energy call in vdW if clause
   !!  SOURCE
   !!
   !subroutine get_E_and_F(fixed_potential, vary_mu, total_energy, &
@@ -307,7 +309,8 @@ contains
     end if
     ! calculate vdW energy correction to xc energy
     if (flag_vdWDFT) then
-       call get_energy(total_energy)
+       ! I don't think that this should be here DRB 2021/07/28
+       !call get_energy(total_energy)
        if (inode == ionode) &
             write (io_lun, '(/,10x,a,/)') &
                    'Calculating van der Waals correction...'
@@ -325,25 +328,6 @@ contains
                 (total_energy + vdW_energy_correction) * en_conv, &
                 en_units(energy_units)
        end if
-! LT_debug 2012/04/30 begin
-!        flag_vdWDFT_slow = .false.
-!        if (flag_vdWDFT_slow) then
-!           if (inode == ionode) &
-!                write (io_lun, '(/,8x,a,/)') &
-!                      'Calculating van der Waals correction the slow way...'
-!           call vdWXC_energy_slow(density, vdW_xc_energy)
-!           vdW_energy_correction = vdW_xc_energy - xc_energy
-!           if (inode == ionode) then
-!              write (io_lun, '(10x,a,f25.15," ",a2)') &
-!                    'van der Waals correction to XC-energy : ', &
-!                    vdW_energy_correction * en_conv, en_units(energy_units)
-!              write (io_lun, '(10x,a,f25.15," ",a2)') &
-!                    'Harris-Foulkes Energy after vdW correction : ', &
-!                    (total_energy + vdW_energy_correction) * en_conv, &
-!                    en_units(energy_units)
-!           end if
-!        end if
-! LT_debug 2012/04/30 end
     end if
 
 !****lat<$


### PR DESCRIPTION
Implement new subroutines to find the Hartree, XC and local pseudopotential/neutral atom energy from the output density so that the formal definition of DFT energy is calculated.  Also remove the check_DFT parameter.  Some tidying associated with unnecessary calls to `get_energy`.