### PR TITLE
Create write_extxyz() for output a .xyz file with extended format

### DIFF
--- a/src/control.f90
+++ b/src/control.f90
@@ -1420,7 +1420,7 @@ subroutine update_pos_and_box(baro, nequil, flag_movable)
   subroutine write_md_data(iter, thermo, baro, mdl, nequil)
 
     use GenComms,      only: inode, ionode
-    use io_module,     only: write_xsf
+    use io_module,     only: write_xsf, write_extxyz
     use global_module, only: iprint_MD, flag_baroDebug, flag_thermoDebug, &
          flag_heat_flux
     use md_model,      only: type_md_model, md_tdep
@@ -1428,7 +1428,8 @@ subroutine update_pos_and_box(baro, nequil, flag_movable)
          write_md_checkpoint, flag_write_xsf, &
          md_thermo_file, md_baro_file, &
          md_trajectory_file, md_frames_file, &
-         md_stats_file, md_heat_flux_file
+         md_stats_file, md_heat_flux_file, &
+         flag_write_extxyz
 
     ! Passed variables
     type(type_barostat), intent(inout)    :: baro
@@ -1442,6 +1443,8 @@ subroutine update_pos_and_box(baro, nequil, flag_movable)
     call write_md_checkpoint(thermo, baro)
     call mdl%dump_stats(md_stats_file, nequil)
     if (flag_write_xsf) call write_xsf(md_trajectory_file, iter)
+    if (flag_write_extxyz) &
+       call write_extxyz('trajectory.xyz', mdl%dft_total_energy, mdl%atom_force)
     if (flag_heat_flux) call mdl%dump_heat_flux(md_heat_flux_file)
     if (mod(iter, MDfreq) == 0) then
        call mdl%dump_frame(md_frames_file)

--- a/src/control.f90
+++ b/src/control.f90
@@ -1415,6 +1415,9 @@ subroutine update_pos_and_box(baro, nequil, flag_movable)
   !!   Zamaan Raza
   !!  CREATION DATE
   !!   2018/08/11 10:27
+  !!  MODIFIED
+  !!   2021/10/19 Jianbo Lin
+  !!    Added call for extended XYZ output (includes forces)
   !!  SOURCE
   !!  
   subroutine write_md_data(iter, thermo, baro, mdl, nequil)

--- a/src/initial_read_module.f90
+++ b/src/initial_read_module.f90
@@ -70,7 +70,8 @@ module initial_read
   integer, save :: index_MatrixFile
   
   ! System signature
-  character(len=80) :: titles
+  ! Moved here from read_and_write so that it can be used for extended XYZ output
+  character(len=80), save :: titles
 
 !!***
 

--- a/src/initial_read_module.f90
+++ b/src/initial_read_module.f90
@@ -68,6 +68,9 @@ module initial_read
 
   ! Index number for loading DM etc
   integer, save :: index_MatrixFile
+  
+  ! System signature
+  character(len=80) :: titles
 
 !!***
 
@@ -224,7 +227,7 @@ contains
     ! Local variables
     character(len=80) :: sub_name = "read_and_write"
     type(cq_timer)    :: backtrace_timer
-    character(len=80) :: titles, def
+    character(len=80) :: def
     character(len=80) :: atom_coord_file
     character(len=80) :: part_coord_file
 
@@ -901,7 +904,7 @@ contains
          flag_write_xsf, md_cell_nhc, md_nhc_cell_mass, &
          md_calc_xlmass, md_equil_steps, md_equil_press, &
          md_tau_T_equil, md_tau_P_equil, md_p_drag, &
-         md_t_drag, md_cell_constraint
+         md_t_drag, md_cell_constraint, flag_write_extxyz
     use md_model,   only: md_tdep
     use move_atoms,         only: threshold_resetCD, &
          flag_stop_on_empty_bundle, &
@@ -2003,6 +2006,7 @@ contains
     flag_SFcoeffReuse = fdf_boolean('AtomMove.ReuseSFcoeff',.true.)
     flag_LmatrixReuse = fdf_boolean('AtomMove.ReuseDM',.true.)
     flag_write_xsf    = fdf_boolean('AtomMove.WriteXSF', .true.)
+    flag_write_extxyz = fdf_boolean('AtomMove.WriteExtXYZ', .false.)
     ! tsuyoshi 2019/12/30
     if(flag_SFcoeffReuse .and. .not.flag_LmatrixReuse) then
        call cq_warn(sub_name,' AtomMove.ReuseDM should be true if AtomMove.ReuseSFcoeff is true.')

--- a/src/md_control_module.f90
+++ b/src/md_control_module.f90
@@ -86,7 +86,8 @@ module md_control
                    md_tau_T_equil, md_tau_P_equil, md_p_drag, md_t_drag, &
                    md_equil_press
   integer       :: md_n_nhc, md_n_ys, md_n_mts, md_equil_steps
-  logical       :: flag_write_xsf, md_cell_nhc, md_calc_xlmass, flag_nhc
+  logical       :: flag_write_xsf, md_cell_nhc, md_calc_xlmass, flag_nhc, &
+                   flag_write_extxyz
   logical       :: flag_extended_system = .false.
   real(double), dimension(3,3), target      :: lattice_vec
   real(double), dimension(:), allocatable   :: md_nhc_mass, md_nhc_cell_mass


### PR DESCRIPTION
The extended format type xyz file can attach information not only atomic positions, but also lattice vectors, energy, forces, etc.
The benefit of this format is that it can be recognized by Python Library ASE and very convenient to do machine learning with such data.
With ASE, it is easy to do further structure analysis or converting to other format of geometry, also preparation of Machine learning.
Add config_type (crystal_Si, liquid_Si, amorphous_Si, mono_vacancy_Si, etc.) to comment line from IO.Title with which people can easily separate or select the geometries in the same xyz file.