### PR TITLE
Revised the part to print out (local) potentials. (Hartree, Pseudopotential, XC, Electrostatic, and total)

### DIFF
--- a/docs/input_tags.rst
+++ b/docs/input_tags.rst
@@ -245,7 +245,8 @@ IO.DumpL (*boolean*)
 
     *default*: T
 
-IO.DumpChargeDensity (*boolean*) Whether to write out the charge
+IO.DumpChargeDensity (*boolean*)
+    Whether to write out the charge
     density.  If T, then the charge density will be written out at
     self-consistency; additionally, if ``IO.Iprint_SC`` is larger than
     2, the charge density will be written out at every step of the SCF
@@ -253,8 +254,17 @@ IO.DumpChargeDensity (*boolean*) Whether to write out the charge
     format files using the :ref:`post-processing utility
     <et_post_process>`.
 
-    *default*: T
+    *default*: F
 
+IO.Dump[Har|XC|PS|ES|Tot]Pot (*boolean*)
+    Flags to allow dumping of different local potentials (Hartree, XC, pseudopotential, electrostatic, total).
+    Only active when a static self-consistent run is chosen. (NB each flag must be set to true for output,
+    such as ``IO.DumpHarPot T`` etc.)  Files can be converted to cube format as for charge density by setting
+    ``Process.ChargeStub`` appropriately (e.g. ``locpsHar`` with other files replacing Har
+    with XC, PS, ES and Tot)
+
+    *default*: F
+    
 IO.TimingOn (*boolean*)
     Whether time information will be measured and written to output
 

--- a/src/H_matrix_module.f90
+++ b/src/H_matrix_module.f90
@@ -823,37 +823,10 @@ contains
           call axpy(n_my_grid_points, one, pseudopotential, 1, density_wk_tot, 1)
           call dump_locps("EStot", density_wk_tot, size, inode)
 
-          deallocate(density_wk, STAT=stat)
+          deallocate(density_wk_tot, STAT=stat)
           if (stat /= 0) &
            call cq_abort("Error deallocating density_wk_tot: ", stat)
           call reg_dealloc_mem(area_ops, size, type_dbl)
-
-        !old  : 
-        !  using density_wk for dump electrostatic potential
-          allocate(density_wk(size,nspin), STAT=stat)
-          if (stat /= 0) &
-           call cq_abort("Error allocating density_wk : ", stat)
-          call reg_alloc_mem(area_ops, size * nspin, type_dbl)
-         density_wk =zero
-
-         ! total_loc_potential = loc_Har + loc_ps + loc_XC
-         !    loc_ES (ElectroStatic) = loc_Har + loc_ps
-         do spin = 1, nspin
-          call copy(n_my_grid_points, potential(:,spin), 1, density_wk(:,spin), 1)
-          call axpy(n_my_grid_points, -one, xc_potential(:,spin), 1, &
-                    density_wk(:,spin), 1)
-         end do
-          if (nspin == 1) then
-             call dump_locps("ES", density_wk(:,1), size, inode)
-          else
-             call dump_locps("ES_up", density_wk(:,1), size, inode)
-             call dump_locps("ES_dn", density_wk(:,2), size, inode)
-          end if
-         deallocate(density_wk, STAT=stat)
-         if (stat /= 0) &
-            call cq_abort("Error deallocating density_wk: ", stat)
-         call reg_dealloc_mem(area_ops, size* nspin, type_dbl)
-
        end if
     end if
     !

--- a/src/H_matrix_module.f90
+++ b/src/H_matrix_module.f90
@@ -812,11 +812,27 @@ contains
          !    call dump_locps("Total_dn", potential(:,2), size, inode)
          ! end if
         ! Change (2022/Dec/09) : Electrostaic potential is now dumped.
+        !  using density_wk_tot for dump electrostatic potential
+          allocate(density_wk_tot(size), STAT=stat)
+          if (stat /= 0) &
+           call cq_abort("Error allocating density_wk_tot : ", stat)
+          call reg_alloc_mem(area_ops, size, type_dbl)
+
+          density_wk_tot =zero
+          call copy(n_my_grid_points, h_potential, 1, density_wk_tot, 1)
+          call axpy(n_my_grid_points, one, pseudopotential, 1, density_wk_tot, 1)
+          call dump_locps("EStot", density_wk_tot, size, inode)
+
+          deallocate(density_wk, STAT=stat)
+          if (stat /= 0) &
+           call cq_abort("Error deallocating density_wk_tot: ", stat)
+          call reg_dealloc_mem(area_ops, size, type_dbl)
+
+        !old  : 
         !  using density_wk for dump electrostatic potential
           allocate(density_wk(size,nspin), STAT=stat)
           if (stat /= 0) &
-            call cq_abort("Error allocating density_wk : ", &
-                          stat)
+           call cq_abort("Error allocating density_wk : ", stat)
           call reg_alloc_mem(area_ops, size * nspin, type_dbl)
          density_wk =zero
 

--- a/src/H_matrix_module.f90
+++ b/src/H_matrix_module.f90
@@ -779,7 +779,7 @@ contains
     !
     ! Print potential, if necessary
     if (locps_output) then
-       if (flag_dump_locps(1)) call dump_locps("Hartree", h_potential, size, inode)
+       if (flag_dump_locps(1)) call dump_locps("Har", h_potential, size, inode)
        if (flag_dump_locps(2)) then
           if (nspin == 1) then
              call dump_locps("XC", xc_potential(:,1), size, inode)
@@ -810,10 +810,10 @@ contains
        if (flag_dump_locps(5)) then
         ! dumping Total potential  
           if (nspin == 1) then
-             call dump_locps("Total", potential(:,1), size, inode)
+             call dump_locps("Tot", potential(:,1), size, inode)
           else
-             call dump_locps("Total_up", potential(:,1), size, inode)
-             call dump_locps("Total_dn", potential(:,2), size, inode)
+             call dump_locps("Tot_up", potential(:,1), size, inode)
+             call dump_locps("Tot_dn", potential(:,2), size, inode)
           end if
        endif
     end if

--- a/src/H_matrix_module.f90
+++ b/src/H_matrix_module.f90
@@ -81,8 +81,10 @@ module H_matrix_module
   ! Area identification
   integer, parameter, private :: area = 3
 
-  logical :: locps_output
-  integer :: locps_choice
+  logical :: locps_output=.false.
+  logical :: flag_write_locps
+  integer, parameter :: max_locps_type = 5
+  logical :: flag_dump_locps(max_locps_type)
 
 !!***
 
@@ -632,7 +634,6 @@ contains
     real(double), dimension(:,:), allocatable :: xc_potential
     real(double), dimension(:,:), allocatable :: density_wk ! rho + density_pcc
     real(double), dimension(:),   allocatable :: density_wk_tot
-    integer :: locps_choice_tmp
     !complex(double_cplx), dimension(:), allocatable :: chdenr, locpotr
     real(double), dimension(:),   allocatable :: drho_tot
     character(len=20) :: subname = "get_h_on_atomfns: "
@@ -778,23 +779,8 @@ contains
     !
     ! Print potential, if necessary
     if (locps_output) then
-       dump_pot = (/.false., .false., .false., .false./)
-       locps_choice_tmp = locps_choice
-       if (locps_choice_tmp < 0 .or. locps_choice_tmp > 15) then
-          if (inode == ionode) &
-               write (io_lun, *) 'Bad choice for local potential &
-                                  &printout: no output.'
-       else
-          if (inode == ionode) &
-               write (io_lun, *) 'Writing local potential to file(s).'
-          do i = 4, 1, -1
-             pot_flag = mod(locps_choice_tmp/(2**(i-1)), 2)
-             if (pot_flag > 0) dump_pot(i) = .true.
-             locps_choice_tmp = locps_choice_tmp - pot_flag*(2**(i-1))
-          end do
-       end if
-       if (dump_pot(1)) call dump_locps("Hartree", h_potential, size, inode)
-       if (dump_pot(2)) then
+       if (flag_dump_locps(1)) call dump_locps("Hartree", h_potential, size, inode)
+       if (flag_dump_locps(2)) then
           if (nspin == 1) then
              call dump_locps("XC", xc_potential(:,1), size, inode)
           else
@@ -802,15 +788,8 @@ contains
              call dump_locps("XC_dn", xc_potential(:,2), size, inode)
           end if
        end if
-       if (dump_pot(3)) call dump_locps("PS", pseudopotential, size, inode)
-       if (dump_pot(4)) then
-        ! OLD: dumping Total potential  
-         ! if (nspin == 1) then
-         !    call dump_locps("Total", potential(:,1), size, inode)
-         ! else
-         !    call dump_locps("Total_up", potential(:,1), size, inode)
-         !    call dump_locps("Total_dn", potential(:,2), size, inode)
-         ! end if
+       if (flag_dump_locps(3)) call dump_locps("PS", pseudopotential, size, inode)
+       if (flag_dump_locps(4)) then
         ! Change (2022/Dec/09) : Electrostaic potential is now dumped.
         !  using density_wk_tot for dump electrostatic potential
           allocate(density_wk_tot(size), STAT=stat)
@@ -821,13 +800,22 @@ contains
           density_wk_tot =zero
           call copy(n_my_grid_points, h_potential, 1, density_wk_tot, 1)
           call axpy(n_my_grid_points, one, pseudopotential, 1, density_wk_tot, 1)
-          call dump_locps("EStot", density_wk_tot, size, inode)
+          call dump_locps("ES", density_wk_tot, size, inode)
 
           deallocate(density_wk_tot, STAT=stat)
           if (stat /= 0) &
            call cq_abort("Error deallocating density_wk_tot: ", stat)
           call reg_dealloc_mem(area_ops, size, type_dbl)
        end if
+       if (flag_dump_locps(5)) then
+        ! dumping Total potential  
+          if (nspin == 1) then
+             call dump_locps("Total", potential(:,1), size, inode)
+          else
+             call dump_locps("Total_up", potential(:,1), size, inode)
+             call dump_locps("Total_dn", potential(:,2), size, inode)
+          end if
+       endif
     end if
     !
     !

--- a/src/H_matrix_module.f90
+++ b/src/H_matrix_module.f90
@@ -632,6 +632,7 @@ contains
     real(double), dimension(:,:), allocatable :: xc_potential
     real(double), dimension(:,:), allocatable :: density_wk ! rho + density_pcc
     real(double), dimension(:),   allocatable :: density_wk_tot
+    integer :: locps_choice_tmp
     !complex(double_cplx), dimension(:), allocatable :: chdenr, locpotr
     real(double), dimension(:),   allocatable :: drho_tot
     character(len=20) :: subname = "get_h_on_atomfns: "
@@ -777,8 +778,9 @@ contains
     !
     ! Print potential, if necessary
     if (locps_output) then
-       dump_pot = (/.false., .true., .false., .false./)
-       if (locps_choice < 0 .or. locps_choice > 15) then
+       dump_pot = (/.false., .false., .false., .false./)
+       locps_choice_tmp = locps_choice
+       if (locps_choice_tmp < 0 .or. locps_choice_tmp > 15) then
           if (inode == ionode) &
                write (io_lun, *) 'Bad choice for local potential &
                                   &printout: no output.'
@@ -786,9 +788,9 @@ contains
           if (inode == ionode) &
                write (io_lun, *) 'Writing local potential to file(s).'
           do i = 4, 1, -1
-             pot_flag = mod(locps_choice/(2**(i-1)), 2)
+             pot_flag = mod(locps_choice_tmp/(2**(i-1)), 2)
              if (pot_flag > 0) dump_pot(i) = .true.
-             locps_choice = locps_choice - pot_flag*(2**(i-1))
+             locps_choice_tmp = locps_choice_tmp - pot_flag*(2**(i-1))
           end do
        end if
        if (dump_pot(1)) call dump_locps("Hartree", h_potential, size, inode)

--- a/src/initial_read_module.f90
+++ b/src/initial_read_module.f90
@@ -891,7 +891,7 @@ contains
          flag_MatrixFile_BinaryFormat_Dump_END, atom_output_threshold, flag_coords_xyz
 
     use group_module,     only: part_method, HILBERT, PYTHON
-    use H_matrix_module,  only: locps_output, locps_choice
+    use H_matrix_module,  only: flag_write_locps, flag_dump_locps
     use pao_minimisation, only: InitStep_paomin
     use timer_module,     only: time_threshold,lun_tmr, TimingOn, &
          TimersWriteOut, BackTraceOn
@@ -1081,8 +1081,13 @@ contains
     !
     flag_dump_bib = fdf_boolean('IO.DumpBibTeX',      .true.)
     flag_dump_L   = fdf_boolean('IO.DumpL',           .true. )
-    locps_output  = fdf_boolean('IO.LocalPotOutput',  .false.)
-    locps_choice  = fdf_integer('IO.LocalPotChoice',   8     )
+    !flag for dumping locps
+    flag_dump_locps(1) = fdf_boolean('IO.DumpHarPot',  .false.)
+    flag_dump_locps(2) = fdf_boolean('IO.DumpXCPot',  .false.)
+    flag_dump_locps(3) = fdf_boolean('IO.DumpPSPot',  .false.)
+    flag_dump_locps(4) = fdf_boolean('IO.DumpESPot',  .false.)
+    flag_dump_locps(5) = fdf_boolean('IO.DumpTotPot',  .false.)
+    flag_write_locps = any(flag_dump_locps(:))
     atomch_output = fdf_boolean('IO.AtomChargeOutput',.false.)
     !
     ! Seed for RNG

--- a/src/minimise.f90
+++ b/src/minimise.f90
@@ -163,6 +163,7 @@ contains
     use units
     use io_module,         only: return_prefix
     use DiagModule,        only: nkp
+    use H_matrix_module,   only: flag_write_locps, locps_output
 
     implicit none
 
@@ -364,11 +365,13 @@ contains
 !****lat>$
 
     ! output WFs or DOS
-    if (flag_self_consistent.AND.(flag_out_wf.OR.flag_write_DOS)) then
-       wf_self_con=.true.
+    if (flag_self_consistent.AND.(flag_out_wf.OR.flag_write_DOS.OR.flag_write_locps)) then
+       if(flag_out_wf.OR.flag_write_DOS) wf_self_con=.true.
+       if(flag_write_locps) locps_output=.true.
        call FindMinDM(n_L_iterations, vary_mu, L_tolerance,&
             reset_L, .false.)
        wf_self_con=.false.
+       locps_output=.false.
     end if
 
     call stop_print_timer(tmr_l_energy, "calculating ENERGY", &


### PR DESCRIPTION
The part to print out local potentials, such as Hartree, Pseudopotential, XC, Electrostatic, and total potentials has been changed. Now, we need at least one of `IO.DumpHarPot`, `IO.DumpXCPot`,  `IO.DumpPSPot`, `IO.DumpESPot` and `IO.DumpTotPot` need to be set `true`.  
 It is valid only in "static" calculations and these files are printed out only once at the end of each job.
