### PR TITLE
Add limit to distance moved by atoms in SQNM

### DIFF
--- a/docs/input_tags.rst
+++ b/docs/input_tags.rst
@@ -743,13 +743,15 @@ Go to :ref:`top <input_tags>`.
 Moving Atoms
 ------------
 AtomMove.TypeOfRun (*string*)
-    values: static/cg/lbfgs/md
+    values: static/cg/sqnm/lbfgs/md
 
     Options:
 
     static — Single point calculation
 
     cg — Structure optimisation by conjugate gradients
+
+    sqnm - Stabilised Quasi-Newton Minimisation (recommended approach)
 
     lbfgs — Structure optimisation by LBFGS (Limited Memory Broyden–Fletcher–Goldfarb–Shanno algorithm)
 
@@ -778,6 +780,13 @@ AtomMove.MaxForceTol (*real*)
 
     *default*: 0.0005 Ha/bohr
 
+AtomMove.MaxSQNMStep (*real*)
+    The maximum distance any atom can move during SQNM (in Bohr).  Applies to the
+    part of the search direction not in the SQNM subspace (scaled directly by a step
+    size, which is limited to ensure this value is not exceeded).
+
+    *default*: 0.2 bohr
+    
 AtomMove.Timestep (*real*)
     Time step for molecular dynamics
 

--- a/src/initial_read_module.f90
+++ b/src/initial_read_module.f90
@@ -867,7 +867,7 @@ contains
          InvSDeltaOmegaTolerance
     use blip,          only: blip_info, init_blip_flag, alpha, beta
     use maxima_module, only: lmax_ps
-    use control,       only: MDn_steps, MDfreq, MDcgtol, CGreset, LBFGS_history
+    use control,       only: MDn_steps, MDfreq, MDcgtol, CGreset, LBFGS_history, sqnm_trust_step
     use ion_electrostatic,  only: ewald_accuracy
     use minimise,      only: UsePulay, n_L_iterations,          &
          n_support_iterations, L_tolerance, &
@@ -1560,6 +1560,7 @@ contains
     MDfreq                = fdf_integer('AtomMove.OutputFreq',    50        )
     MDtimestep            = fdf_double ('AtomMove.Timestep',      0.5_double)
     MDcgtol               = fdf_double ('AtomMove.MaxForceTol',0.0005_double)
+    sqnm_trust_step       = fdf_double ('AtomMove.MaxSQNMStep',0.2_double   )
     LBFGS_history         = fdf_integer('AtomMove.LBFGSHistory', 5          )
     flag_opt_cell         = fdf_boolean('AtomMove.OptCell',          .false.)
     flag_variable_cell    = flag_opt_cell


### PR DESCRIPTION
Implement a check on the unrestricted atom movement in SQNM so that the alpha parameter is not increased without limit.