### PR TITLE
Updates for blips as a basis

### DIFF
--- a/src/blip_minimisation.module.f90
+++ b/src/blip_minimisation.module.f90
@@ -118,6 +118,8 @@ contains
   !!    Renamed supportfns -> atomfns
   !!   2017/02/23 dave
   !!    - Changing location of diagon flag from DiagModule to global and name to flag_diagonalisation
+  !!   2022/12/14 13:03 dave
+  !!    Change to save initial energy in total_energy_0 from new_SC_potl
   !!  SOURCE
   !!
   subroutine vary_support(n_support_iterations, fixed_potential, &
@@ -221,6 +223,7 @@ contains
     call new_SC_potl(.false., con_tolerance, reset_L,             &
          fixed_potential, vary_mu, n_L_iterations, &
          tolerance, total_energy_last)
+    total_energy_0 = total_energy_last
     ! now obtain the gradient of the energy with respect to support
     ! functions. For diagonalisation, this is already stored
     if (inode == ionode .and. iprint_basis > 2) &
@@ -500,6 +503,8 @@ contains
   !!   - removed k0, it seemed not used and redundant
   !!   2017/02/23 dave
   !!    - Changing location of diagon flag from DiagModule to global and name to flag_diagonalisation
+  !!   2022/12/14 13:03 dave
+  !!    Tweak to make initial k3 larger
   !!  SOURCE
   !!
   subroutine line_minimise_support(search_direction, lengthBlip,  &
@@ -578,7 +583,7 @@ contains
           ! DRB 2004/03/03
           tmp = vdot(lengthBlip, search_direction, 1, grad_coeff_array, 1)
           if (abs(dE) < RD_ERR) then
-             k3 = 0.008_double
+             k3 = 0.2_double ! A little conservative
              dE = tmp * k3
           else
              k3 = half * dE / tmp

--- a/src/initial_read_module.f90
+++ b/src/initial_read_module.f90
@@ -2136,7 +2136,7 @@ contains
        restart_DM         = fdf_boolean('General.LoadDM', .true.)
        find_chdens    = fdf_boolean('SC.MakeInitialChargeFromK',.true.)
        if (flag_XLBOMD) restart_X=fdf_boolean('XL.LoadX', .true.)
-       if (flag_multisite) read_option = fdf_boolean('Basis.LoadCoeffs', .true.)
+       if (flag_multisite .or. flag_basis_set==blips) read_option = fdf_boolean('Basis.LoadCoeffs', .true.)
     else
        flag_read_velocity = fdf_boolean('AtomMove.ReadVelocity',.false.)
        restart_DM         = fdf_boolean('General.LoadDM', .false.)
@@ -2146,7 +2146,7 @@ contains
           find_chdens    = fdf_boolean('SC.MakeInitialChargeFromK',.false.)
        endif
        if (flag_XLBOMD) restart_X=fdf_boolean('XL.LoadX', .false.)
-       if (flag_multisite) read_option = fdf_boolean('Basis.LoadCoeffs', .false.)
+       if (flag_multisite .or. flag_basis_set==blips) read_option = fdf_boolean('Basis.LoadCoeffs', .false.)
     end if
 
     if (restart_DM .and. flag_Multisite .and. .not.read_option) then
@@ -2575,6 +2575,8 @@ contains
   !!    - Changing location of diagon flag from DiagModule to global and name to flag_diagonalisation
   !!   2022/10/28 lionel
   !!    Add printing of species table in ASE output
+  !!   2022/12/14 11:31 dave
+  !!    Removed output of support grid spacing with blips (shouldn't be here: species dependent)
   !!  SOURCE
   !!
   subroutine write_info(titles, mu, vary_mu, HNL_fac, NODES)
@@ -2659,9 +2661,7 @@ contains
     ! Ground state search details
     write(io_lun,fmt='(/4x,"Ground state search:")')
     if(flag_basis_set==blips) then 
-       write(io_lun,'(6x,"Support functions represented with blip basis")') 
-       write(io_lun,'(6x,"Support-grid spacing: ",f7.4,1x,a2)') &
-            dist_conv*blip_info(n)%SupportGridSpacing, d_units(dist_units)
+       write(io_lun,'(6x,"Support functions represented with blip basis")')
     else
        write(io_lun,'(6x,"Support functions represented with PAO basis")') 
        if(flag_Multisite) then

--- a/src/initialisation_module.f90
+++ b/src/initialisation_module.f90
@@ -1110,7 +1110,7 @@ contains
          flag_out_wf, wf_self_con, &
          flag_write_DOS, flag_neutral_atom, &
          atomf, sf, flag_LFD, nspin_SF, flag_diagonalisation, &
-         ne_in_cell, min_layer
+         ne_in_cell, min_layer, flag_basis_set, PAOs
     use ion_electrostatic,   only: ewald, screened_ion_interaction
     use S_matrix_module,     only: get_S_matrix
     use GenComms,            only: my_barrier,end_comms,inode,ionode, &
@@ -1203,7 +1203,7 @@ contains
     endif
 
     ! (0) If we use PAOs and contract them, prepare SF-PAO coefficients here
-    if (atomf.ne.sf) then
+    if ((atomf .ne. sf) .and. flag_basis_set==PAOs) then
        if (restart_rho) then
           ! Read density from input files here to make SF-PAO coefficients
           if (nspin == 2) then

--- a/src/move_atoms.module.f90
+++ b/src/move_atoms.module.f90
@@ -4961,7 +4961,7 @@ contains
     use numbers,         only: half, zero, one, very_small
     use global_module,   only: flag_diagonalisation, atom_coord, atom_vels, atom_coord_diff, &
          rcellx, rcelly, rcellz, ni_in_cell, nspin, nspin_SF, id_glob, &
-         area_moveatoms
+         area_moveatoms, flag_basis_set, blips
     ! n_proc_old and glob2node_old have been removed
     use GenComms,        only: my_barrier, inode, ionode, cq_abort, gcopy
     use mult_module,     only: matL, L_trans, matK, matS, S_trans, matSFcoeff, SFcoeff_trans, &
@@ -5030,6 +5030,7 @@ contains
        if(inode .eq. ionode) write(io_lun,*) 'Update_Pos_and_Matrices:: updateX is not implemented yet.'
     case(updateSFcoeff)
        flag_SFcoeff=.true.
+       if(flag_basis_set==blips) flag_SFcoeff = .false. ! Blips saved elsewhere
        if(flag_diagonalisation) then
           flag_K=.true.
        else

--- a/src/store_matrix_module.f90
+++ b/src/store_matrix_module.f90
@@ -134,7 +134,7 @@ contains
     ! Module usage
     use global_module, ONLY: ni_in_cell, nspin, nspin_SF, flag_diagonalisation, flag_Multisite, &
          flag_XLBOMD, flag_propagateX, flag_dissipation, integratorXL, flag_SFcoeffReuse, &
-         flag_DumpMatrices
+         flag_DumpMatrices, flag_basis_set, PAOs
     use matrix_data, ONLY: Lrange, Hrange, SFcoeff_range, SFcoeffTr_range, HTr_range, Srange, LSrange
     use mult_module, ONLY: matL,L_trans, matK, matSFcoeff, matS
     use io_module, ONLY: append_coords, pdb_template, write_atomic_positions
@@ -164,7 +164,8 @@ contains
     index_local = 0; if(present(index)) index_local=index
     MDstep_local = 0; if(present(MDstep)) MDstep_local=MDstep
 
-    if(flag_SFcoeffReuse .or. flag_Multisite) then
+    ! Blip coefficients are saved separately
+    if(flag_basis_set==PAOs .and. (flag_SFcoeffReuse .or. flag_Multisite)) then
        call dump_matrix_update('SFcoeff',matSFcoeff,SFcoeff_range,&
             index=index_local,nspin=nspin_SF,iprint_mode=mat,MDstep=MDstep_local)
     endif


### PR DESCRIPTION
Main change is to fix the crash on saving SF coefficients (which aren't defined for blips) but also to allow loading of blip coefficients at job start and small tweaks to blip minimisation