### PR TITLE
Refactor the testsuite

### DIFF
--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -22,11 +22,6 @@ These steps can be run automatically using the script `run_conquest_test.sh` in 
 
 To add new tests
 
-  1. Add input files and a sample output file (run with `IO.Iprint 0` and named `Conquest_out.ref`) in a new subdirectory under [testsuite](./). The naming convention is test directory names start with `test_` followed by a running index with three digits, e.g. `003`.
-  2. Add an entry to the `"test_path"` parameter in [test_check_output.py](./test_check_output.py). The test driver will check for all fields in the output listed in the `"key"` parameter. They are read from the [Conquest_out](test_001_bulk_Si_1proc_Diag/Conquest_out.ref) file by the `read_conquest_out()` function.
+  1. Add input files and a sample output file (run with `IO.Iprint 0` and named `Conquest_out.ref`) in a new subdirectory under [testsuite](./). The naming convention is test directory names start with `test_` followed by a running index with three digits, e.g. `004`.
+  2. Add a test to `TestClass` in [`test_check_output.py`](./test_check_output.py). You can use one of the current tests, named `test_XXX` as templates. Update the directory name passed to `path` and the list of parameters in the `@pytest.mark.parametrize` decorator. The parameters are the fields in `Conquest_out` to be checked against the reference. If necessary, update the `read_conquest_out()` function to parse a new field from the output.
   3. Add it as a new `Run test XXX` step to the [CI workflow](../.github/workflows/makefile.yml)
-  4. *optional* If a new field in the output needs to be checked, these things are required:
-     - Add the logic how to read the line of output to the loop `for line in file.readlines()` in `read_conquest_out()`. The result should be stored in the dictionary `Results`.
-     - Add the new key from the dictionary `Results` to the `"key"` parameter for `test_check_outputs()`.
-     - By default all keys are checked in all tests. If the new key creates errors in the previous tests (e.g. it is not found in their output), add the offending combination(s) to the `xfail_test` logical variable, so that failures in those tests are expected and don't throw errors. See the `"Not-a-real-key"` key as an example.
-  5. *optional* By default the fields are checked to 6 decimal precision. If a custom precision is required, add it to the `custom_precision` dictionary with the corresponding key.

--- a/testsuite/test_check_output.py
+++ b/testsuite/test_check_output.py
@@ -28,7 +28,9 @@ def read_conquest_out(path=".", filename="Conquest_out"):
     return Results
 
 def results(path, key):
-
+    '''
+    Reads a result and its reference, selects one value with key and returns it.
+    '''
     ref_result = read_conquest_out(path, "Conquest_out.ref")
     test_result = read_conquest_out(path, "Conquest_out")
 
@@ -36,6 +38,9 @@ def results(path, key):
 
 @pytest.fixture
 def precision():
+    '''
+    Return the relative tolerance used by tests
+    '''
 
     return 1e-4
 

--- a/testsuite/test_check_output.py
+++ b/testsuite/test_check_output.py
@@ -38,14 +38,14 @@ def results(path, key):
     return (ref_result[key], test_result[key])
 
 @pytest.fixture
-def directory():
+def testsuite_directory():
     '''
     Return path to testsuite
     '''
     return pathlib.Path(__file__).parent.resolve()
 
 @pytest.fixture
-def precision():
+def default_precision():
     '''
     Return the relative tolerance used by tests
     '''
@@ -57,28 +57,28 @@ class TestClass:
                                     'Max force',
                                     'Force residual',
                                     'Total stress'])
-    def test_001(self, key, precision, directory):
+    def test_001(self, key, default_precision, testsuite_directory):
 
-        path = os.path.join(directory, "test_001_bulk_Si_1proc_Diag")
+        path = os.path.join(testsuite_directory, "test_001_bulk_Si_1proc_Diag")
         res = results(path, key)
-        np.testing.assert_allclose(res[0], res[1], rtol = precision, verbose = True)
+        np.testing.assert_allclose(res[0], res[1], rtol = default_precision, verbose = True)
 
     @pytest.mark.parametrize("key", ['Harris-Foulkes energy',
                                      'Max force',
                                      'Force residual',
                                      'Total stress'])
-    def test_002(self, key, precision, directory):
+    def test_002(self, key, default_precision, testsuite_directory):
 
-        path = os.path.join(directory, "test_002_bulk_Si_1proc_OrderN")
+        path = os.path.join(testsuite_directory, "test_002_bulk_Si_1proc_OrderN")
         res = results(path, key)
-        np.testing.assert_allclose(res[0], res[1], rtol = precision, verbose = True)
+        np.testing.assert_allclose(res[0], res[1], rtol = default_precision, verbose = True)
 
     @pytest.mark.parametrize("key", ['Harris-Foulkes energy',
                                      'Max force',
                                      'Force residual',
                                      'Total polarisation'])
-    def test_003(self, key, precision, directory):
+    def test_003(self, key, default_precision, testsuite_directory):
 
-        path = os.path.join(directory, "test_003_bulk_BTO_polarisation")
+        path = os.path.join(testsuite_directory, "test_003_bulk_BTO_polarisation")
         res = results(path, key)
-        np.testing.assert_allclose(res[0], res[1], rtol = precision, verbose = True)
+        np.testing.assert_allclose(res[0], res[1], rtol = default_precision, verbose = True)

--- a/testsuite/test_check_output.py
+++ b/testsuite/test_check_output.py
@@ -1,6 +1,7 @@
 import numpy as np
 import os
 import pytest
+import pathlib
 
 def read_conquest_out(path=".", filename="Conquest_out"):
     '''
@@ -10,7 +11,7 @@ def read_conquest_out(path=".", filename="Conquest_out"):
     Returns a dictionary with float values.
     '''
     path_to_file = os.path.join(path,filename)
-    assert os.path.exists(path_to_file)
+    assert os.path.exists(path_to_file), path_to_file
     file = open(path_to_file, 'r')
     Results = dict()
     for line in file.readlines():
@@ -37,6 +38,13 @@ def results(path, key):
     return (ref_result[key], test_result[key])
 
 @pytest.fixture
+def directory():
+    '''
+    Return path to testsuite
+    '''
+    return pathlib.Path(__file__).parent.resolve()
+
+@pytest.fixture
 def precision():
     '''
     Return the relative tolerance used by tests
@@ -48,25 +56,28 @@ def precision():
                                 'Max force',
                                 'Force residual',
                                 'Total stress'])
-def test_001(key, precision):
+def test_001(key, precision, directory):
 
-    res = results("test_001_bulk_Si_1proc_Diag", key)
+    path = os.path.join(directory, "test_001_bulk_Si_1proc_Diag")
+    res = results(path, key)
     np.testing.assert_allclose(res[0], res[1], rtol = precision, verbose = True)
 
 @pytest.mark.parametrize("key", ['Harris-Foulkes energy',
                                  'Max force',
                                  'Force residual',
                                  'Total stress'])
-def test_002(key, precision):
+def test_002(key, precision, directory):
 
-    res = results("test_002_bulk_Si_1proc_OrderN", key)
+    path = os.path.join(directory, "test_002_bulk_Si_1proc_OrderN")
+    res = results(path, key)
     np.testing.assert_allclose(res[0], res[1], rtol = precision, verbose = True)
 
 @pytest.mark.parametrize("key", ['Harris-Foulkes energy',
                                  'Max force',
                                  'Force residual',
                                  'Total polarisation'])
-def test_003(key, precision):
+def test_003(key, precision, directory):
 
-    res = results("test_003_bulk_BTO_polarisation", key)
+    path = os.path.join(directory, "test_003_bulk_BTO_polarisation")
+    res = results(path, key)
     np.testing.assert_allclose(res[0], res[1], rtol = precision, verbose = True)

--- a/testsuite/test_check_output.py
+++ b/testsuite/test_check_output.py
@@ -27,37 +27,41 @@ def read_conquest_out(path=".", filename="Conquest_out"):
 
     return Results
 
-@pytest.mark.parametrize("test_path", ["test_001_bulk_Si_1proc_Diag",
-                                       "test_002_bulk_Si_1proc_OrderN",
-                                       "test_003_bulk_BTO_polarisation"])
+def results(path, key):
+
+    ref_result = read_conquest_out(path, "Conquest_out.ref")
+    test_result = read_conquest_out(path, "Conquest_out")
+
+    return (ref_result[key], test_result[key])
+
+@pytest.fixture
+def precision():
+
+    return 1e-4
+
 @pytest.mark.parametrize("key",['Harris-Foulkes energy',
                                 'Max force',
                                 'Force residual',
-                                'Total stress',
-                                'Total polarisation',
-                                ])
-def test_check_outputs(test_path, key):
-    '''
-    Reads a predefined set of results written in Conquest_out files of
-    tests 001 - 003 and compares them against results in Conquest_out.ref
-    within a relative tolerance.
-    '''
+                                'Total stress'])
+def test_001(key, precision):
 
-    # Only check polarisation for test003 for now
-    xfail_test = (key == "Total polarisation" and "test_003" not in test_path)
-    if (xfail_test):
-        pytest.xfail("invalid parameter combination: "+test_path+", "+key)
+    res = results("test_001_bulk_Si_1proc_Diag", key)
+    np.testing.assert_allclose(res[0], res[1], rtol = precision, verbose = True)
 
-    # Read data from the directory parameterized by test_path
-    ref_result = read_conquest_out(test_path, "Conquest_out.ref")
-    test_result = read_conquest_out(test_path, "Conquest_out")
+@pytest.mark.parametrize("key", ['Harris-Foulkes energy',
+                                 'Max force',
+                                 'Force residual',
+                                 'Total stress'])
+def test_002(key, precision):
 
-    # Set precision, by default check to 6 decimal numbers
-    default_precision = 1e-4
-    
-    np.testing.assert_allclose(ref_result[key],
-                               test_result[key],
-                               rtol = default_precision,
-                               atol = 0,
-                               err_msg = test_path+": "+key,
-                               verbose = True)
+    res = results("test_002_bulk_Si_1proc_OrderN", key)
+    np.testing.assert_allclose(res[0], res[1], rtol = precision, verbose = True)
+
+@pytest.mark.parametrize("key", ['Harris-Foulkes energy',
+                                 'Max force',
+                                 'Force residual',
+                                 'Total polarisation'])
+def test_003(key, precision):
+
+    res = results("test_003_bulk_BTO_polarisation", key)
+    np.testing.assert_allclose(res[0], res[1], rtol = precision, verbose = True)

--- a/testsuite/test_check_output.py
+++ b/testsuite/test_check_output.py
@@ -52,32 +52,33 @@ def precision():
 
     return 1e-4
 
-@pytest.mark.parametrize("key",['Harris-Foulkes energy',
-                                'Max force',
-                                'Force residual',
-                                'Total stress'])
-def test_001(key, precision, directory):
+class TestClass:
+    @pytest.mark.parametrize("key",['Harris-Foulkes energy',
+                                    'Max force',
+                                    'Force residual',
+                                    'Total stress'])
+    def test_001(self, key, precision, directory):
 
-    path = os.path.join(directory, "test_001_bulk_Si_1proc_Diag")
-    res = results(path, key)
-    np.testing.assert_allclose(res[0], res[1], rtol = precision, verbose = True)
+        path = os.path.join(directory, "test_001_bulk_Si_1proc_Diag")
+        res = results(path, key)
+        np.testing.assert_allclose(res[0], res[1], rtol = precision, verbose = True)
 
-@pytest.mark.parametrize("key", ['Harris-Foulkes energy',
-                                 'Max force',
-                                 'Force residual',
-                                 'Total stress'])
-def test_002(key, precision, directory):
+    @pytest.mark.parametrize("key", ['Harris-Foulkes energy',
+                                     'Max force',
+                                     'Force residual',
+                                     'Total stress'])
+    def test_002(self, key, precision, directory):
 
-    path = os.path.join(directory, "test_002_bulk_Si_1proc_OrderN")
-    res = results(path, key)
-    np.testing.assert_allclose(res[0], res[1], rtol = precision, verbose = True)
+        path = os.path.join(directory, "test_002_bulk_Si_1proc_OrderN")
+        res = results(path, key)
+        np.testing.assert_allclose(res[0], res[1], rtol = precision, verbose = True)
 
-@pytest.mark.parametrize("key", ['Harris-Foulkes energy',
-                                 'Max force',
-                                 'Force residual',
-                                 'Total polarisation'])
-def test_003(key, precision, directory):
+    @pytest.mark.parametrize("key", ['Harris-Foulkes energy',
+                                     'Max force',
+                                     'Force residual',
+                                     'Total polarisation'])
+    def test_003(self, key, precision, directory):
 
-    path = os.path.join(directory, "test_003_bulk_BTO_polarisation")
-    res = results(path, key)
-    np.testing.assert_allclose(res[0], res[1], rtol = precision, verbose = True)
+        path = os.path.join(directory, "test_003_bulk_BTO_polarisation")
+        res = results(path, key)
+        np.testing.assert_allclose(res[0], res[1], rtol = precision, verbose = True)

--- a/testsuite/test_check_output.py
+++ b/testsuite/test_check_output.py
@@ -35,20 +35,14 @@ def read_conquest_out(path=".", filename="Conquest_out"):
                                 'Force residual',
                                 'Total stress',
                                 'Total polarisation',
-                                'Not-a-real-key'
                                 ])
 def test_check_outputs(test_path, key):
     '''
     Reads a predefined set of results written in Conquest_out files of
-    tests 001 and 002 and compares them against results in Conquest_out.ref
-    within a tolerance.
+    tests 001 - 003 and compares them against results in Conquest_out.ref
+    within a relative tolerance.
     '''
 
-    # Template for skipping tests. If a parameter combination is added to
-    # xfail_test, pytest will expect the test to fail.
-    xfail_test = (key == "Not-a-real-key")
-    if (xfail_test):
-        pytest.xfail("invalid parameter combination: "+test_path+", "+key)
     # Only check polarisation for test003 for now
     xfail_test = (key == "Total polarisation" and "test_003" not in test_path)
     if (xfail_test):

--- a/testsuite/test_check_output.py
+++ b/testsuite/test_check_output.py
@@ -54,16 +54,10 @@ def test_check_outputs(test_path, key):
 
     # Set precision, by default check to 6 decimal numbers
     default_precision = 1e-4
-    custom_precision = {'Total stress': 1e-4, 'Total polarisation': 1e-4}
-
-    if key in custom_precision:
-        precision = custom_precision[key]
-    else:
-        precision = default_precision
     
     np.testing.assert_allclose(ref_result[key],
                                test_result[key],
-                               rtol = precision,
+                               rtol = default_precision,
                                atol = 0,
                                err_msg = test_path+": "+key,
                                verbose = True)


### PR DESCRIPTION
Closes #200

Each Fortran test now has its own parametrized python test that specifies the values it checks from the output. I would have liked to also make `results` a fixture, but I couldn't figure out how to pass the path into a fixture. 