### PR TITLE
Improve LFD range input

### DIFF
--- a/src/initial_read_module.f90
+++ b/src/initial_read_module.f90
@@ -1387,7 +1387,9 @@ contains
           ! Added DRB 2018/07/16 for safety
           if(flag_Multisite) then
              RadiusMS(i)      = fdf_double ('Atom.MultisiteRange',zero)
-             RadiusLD(i)      = fdf_double ('Atom.LFDRange',zero)
+             RadiusLD(i)      = fdf_double ('Atom.LFDRange',RadiusMS(i))
+             if(RadiusLD(i)<RadiusMS(i)) call cq_warn(sub_name,"LFD range should be larger than MSSF range: ", &
+                  RadiusLD(i),RadiusMS(i))
           end if
           ! Moved to ... so that RadiusAtomf is read from ion files
           !if (flag_Multisite) RadiusSupport(i) = RadiusAtomf(i) + RadiusMS(i)


### PR DESCRIPTION
I have made the LFD range equal to the MSSF range by default, and also added a warning if LFD range is less than MSSF range