### PR TITLE
Change OMP parallel loop to remove errors

### DIFF
--- a/src/PAO_grid_transform_module.f90
+++ b/src/PAO_grid_transform_module.f90
@@ -386,9 +386,9 @@ contains
                    !$omp             schedule(dynamic) &
                    !$omp             reduction(+: temp_block_storage) &
                    !$omp             shared(n_pts_in_block, direction, pao, the_species, offset_position, &
-                   !$omp                    no_of_ib_ia, ip_store, r_store, x_store, y_store, z_store) &
+                   !$omp                    npoint, no_of_ib_ia, ip_store, r_store, x_store, y_store, z_store) &
                    !$omp             private(r_from_i, ip, position, ipoint, &
-                   !$omp                     npoint, x, y, z, &
+                   !$omp                     x, y, z, &
                    !$omp                     l1, acz, m1, count1, val)
                    do ip=1,npoint
                       ipoint=ip_store(ip)

--- a/src/PAO_grid_transform_module.f90
+++ b/src/PAO_grid_transform_module.f90
@@ -140,6 +140,8 @@ contains
     real(double) :: rcut
     real(double) :: r1, r2, r3, r4, core_charge, gauss_charge
     real(double) :: val, theta, phi, r_tmp
+    integer :: max_num_blocks, current_num_blocks
+    real(double), dimension(:), allocatable :: temp_block_storage
 
     call start_timer(tmr_std_basis)
     call start_timer(tmr_std_allocation)
@@ -157,6 +159,9 @@ contains
     no_of_ib_ia = 0
     gridfunctions(pao_fns)%griddata = zero
 
+    max_num_blocks = maxval(npao_species)*n_pts_in_block
+    allocate(temp_block_storage(max_num_blocks))
+    
     ! loop arround grid points in the domain, and for each
     ! point, get the PAO values
 
@@ -168,24 +173,12 @@ contains
           iatom=0
           do ipart=1,naba_atoms_of_blocks(atomf)%no_of_part(iblock)
              jpart=naba_atoms_of_blocks(atomf)%list_part(ipart,iblock)
-             if(jpart > DCS_parts%mx_gcover) then 
-                call cq_abort('single_PAO_to_grid: JPART ERROR ',ipart,jpart)
-             endif
              ind_part=DCS_parts%lab_cell(jpart)
              do ia=1,naba_atoms_of_blocks(atomf)%no_atom_on_part(ipart,iblock)
                 iatom=iatom+1
                 ii = naba_atoms_of_blocks(atomf)%list_atom(iatom,iblock)
                 icover= DCS_parts%icover_ibeg(jpart)+ii-1
                 ig_atom= id_glob(parts%icell_beg(ind_part)+ii-1)
-
-                if(parts%icell_beg(ind_part) + ii-1 > ni_in_cell) then
-                   call cq_abort('single_PAO_to_grid: globID ERROR ', &
-                        ii,parts%icell_beg(ind_part))
-                endif
-                if(icover > DCS_parts%mx_mcover) then
-                   call cq_abort('single_PAO_to_grid: icover ERROR ', &
-                        icover,DCS_parts%mx_mcover)
-                endif
 
                 xatom=DCS_parts%xcover(icover)
                 yatom=DCS_parts%ycover(icover)
@@ -197,17 +190,21 @@ contains
                 rcut = r_h + RD_ERR
                 call check_block (xblock,yblock,zblock,xatom,yatom,zatom, rcut, &  ! in
                      npoint,ip_store,r_store,x_store,y_store,z_store,n_pts_in_block) !out
-                r_from_i = sqrt((xatom-xblock)**2+(yatom-yblock)**2+ &
-                     (zatom-zblock)**2 )
 
                 if(npoint > 0) then
-                   !offset_position = (no_of_ib_ia-1) * npao * n_pts_in_block
+                   current_num_blocks = npao_species(the_species)*n_pts_in_block
+                   temp_block_storage = zero
                    offset_position = no_of_ib_ia
+                   !$omp parallel do default(none) &
+                   !$omp             schedule(dynamic) &
+                   !$omp             reduction(+: temp_block_storage) &
+                   !$omp             shared(n_pts_in_block, pao, the_species, offset_position, &
+                   !$omp                    npoint, no_of_ib_ia, ip_store, r_store, x_store, y_store, z_store) &
+                   !$omp             private(r_from_i, ip, position, ipoint, &
+                   !$omp                     x, y, z, l1, acz, m1, count1, val)
                    do ip=1,npoint
                       ipoint=ip_store(ip)
                       position= offset_position + ipoint
-                      if(position > gridfunctions(pao_fns)%size) call cq_abort &
-                           ('single_pao_to_grid: position error ', position, gridfunctions(pao_fns)%size)
 
                       r_from_i = r_store(ip)
                       x = x_store(ip)
@@ -219,21 +216,23 @@ contains
                          do acz = 1,pao(the_species)%angmom(l1)%n_zeta_in_angmom
                             do m1=-l1,l1
                                call evaluate_pao(the_species,l1,acz,m1,x,y,z,val)
-                               if(position+(count1-1)*n_pts_in_block > gridfunctions(pao_fns)%size) &
-                                    call cq_abort('single_pao_to_grid: position error ', &
-                                    position, gridfunctions(pao_fns)%size)
-                               gridfunctions(pao_fns)%griddata(position+(count1-1)*n_pts_in_block) = val
+                               !gridfunctions(pao_fns)%griddata(position+(count1-1)*n_pts_in_block) = val
+                               temp_block_storage(ipoint + (count1-1)*n_pts_in_block) = val
                                count1 = count1+1
                             end do ! m1
                          end do ! acz
                       end do ! l1
                    enddo ! ip=1,npoint
+                   !$omp end parallel do
+                   gridfunctions(pao_fns)%griddata(no_of_ib_ia+1:no_of_ib_ia+current_num_blocks) = &
+                        temp_block_storage(1:current_num_blocks)
                 endif! (npoint > 0) then
                 no_of_ib_ia = no_of_ib_ia + npao_species(the_species)*n_pts_in_block
              enddo ! naba_atoms
           enddo ! naba_part
        endif !(naba_atoms_of_blocks(atomf)%no_of_part(iblock) > 0) !naba atoms?
     enddo ! iblock : primary set of blocks
+    deallocate(temp_block_storage)
     call my_barrier()
     call start_timer(tmr_std_allocation)
     deallocate(ip_store,x_store,y_store,z_store,r_store)
@@ -254,6 +253,7 @@ contains
 !!   Used for gradients of energy wrt atomic coordinates
 !!
 !!   This subroutine is based on sub:single_PAO_to_grid in PAO_grid_transform_module.f90.
+!!   TODO: There is a lot of code duplication between single_PAO_to_grid and single_PAO_to_grad  
 !!
 !!  INPUTS
 !! 
@@ -303,7 +303,7 @@ contains
     integer :: no_of_ib_ia, offset_position
     integer :: position,iatom
     integer :: stat, nl, npoint, ip
-    integer :: i,m, m1min, m1max,acz,m1,l1,count1, temp_size
+    integer :: i,m, m1min, m1max,acz,m1,l1,count1
     integer     , allocatable :: ip_store(:)
     real(double), allocatable :: x_store(:)
     real(double), allocatable :: y_store(:)
@@ -313,6 +313,7 @@ contains
     real(double) :: rcut
     real(double) :: r1, r2, r3, r4, core_charge, gauss_charge
     real(double) :: val, theta, phi, r_tmp
+    integer :: max_num_blocks, current_num_blocks
     real(double), dimension(:), allocatable :: temp_block_storage
 
     call start_timer(tmr_std_basis)
@@ -331,23 +332,12 @@ contains
     no_of_ib_ia = 0
     gridfunctions(pao_fns)%griddata = zero
 
-    temp_size= maxval(npao_species)*n_pts_in_block
-    allocate(temp_block_storage(temp_size))
+    max_num_blocks = maxval(npao_species)*n_pts_in_block
+    allocate(temp_block_storage(max_num_blocks))
+    
     ! loop arround grid points in the domain, and for each
     ! point, get the d_PAO/d_R values
 
-    !#!!$omp parallel do default(none) &
-    !#!!$omp             schedule(dynamic) &
-    !#!!$omp             shared(domain, dcellx_block, dcelly_block, dcellz_block, atomf, &
-    !#!!$omp                    naba_atoms_of_blocks, parts, r_h, n_pts_in_block, direction, &
-    !#!!$omp                    pao, pao_fns, npao_species, dcs_parts, id_glob, species_glob, &
-    !#!!$omp                    gridfunctions) &
-    !#!!$omp             private(iblock, iatom, ipart, jpart, ind_part, xblock, yblock, zblock, &
-    !#!!$omp                     ii, ia, icover, ig_atom, xatom, yatom, zatom, the_species, &
-    !#!!$omp                     rcut, r_from_i, ip, position, offset_position, ipoint, &
-    !#!!$omp                     npoint, ip_store, r_store, x_store, y_store, z_store, x, y, z, &
-    !#!!$omp                     l1, acz, m1, count1, val) &
-    !#!!$omp             firstprivate(no_of_ib_ia)
     do iblock = 1, domain%groups_on_node ! primary set of blocks
        xblock=(domain%idisp_primx(iblock)+domain%nx_origin-1)*dcellx_block
        yblock=(domain%idisp_primy(iblock)+domain%ny_origin-1)*dcelly_block
@@ -373,14 +363,11 @@ contains
                 rcut = r_h + RD_ERR
                 call check_block (xblock,yblock,zblock,xatom,yatom,zatom, rcut, &  ! in
                      npoint,ip_store,r_store,x_store,y_store,z_store,n_pts_in_block) !out
-                !r_from_i = sqrt( (xatom-xblock)**2 + (yatom-yblock)**2 + (zatom-zblock)**2 )
 
                 if(npoint > 0) then
                    ! Temporary storage
-                   temp_size= npao_species(the_species)*n_pts_in_block
-                   !allocate(temp_block_storage(temp_size))
+                   current_num_blocks = npao_species(the_species)*n_pts_in_block
                    temp_block_storage = zero
-                   !offset_position = (no_of_ib_ia-1) * npao * n_pts_in_block
                    offset_position = no_of_ib_ia
                    !$omp parallel do default(none) &
                    !$omp             schedule(dynamic) &
@@ -388,8 +375,7 @@ contains
                    !$omp             shared(n_pts_in_block, direction, pao, the_species, offset_position, &
                    !$omp                    npoint, no_of_ib_ia, ip_store, r_store, x_store, y_store, z_store) &
                    !$omp             private(r_from_i, ip, position, ipoint, &
-                   !$omp                     x, y, z, &
-                   !$omp                     l1, acz, m1, count1, val)
+                   !$omp                     x, y, z, l1, acz, m1, count1, val)
                    do ip=1,npoint
                       ipoint=ip_store(ip)
                       position= offset_position + ipoint
@@ -418,8 +404,8 @@ contains
                       end do ! l1
                    enddo ! ip=1,npoint
                    !$omp end parallel do
-                   gridfunctions(pao_fns)%griddata(no_of_ib_ia+1:no_of_ib_ia+temp_size) = &
-                        temp_block_storage(1:temp_size)
+                   gridfunctions(pao_fns)%griddata(no_of_ib_ia+1:no_of_ib_ia+current_num_blocks) = &
+                        temp_block_storage(1:current_num_blocks)
                 endif! (npoint > 0) then
                 no_of_ib_ia = no_of_ib_ia + npao_species(the_species)*n_pts_in_block
              enddo ! naba_atoms
@@ -427,7 +413,6 @@ contains
        endif !(naba_atoms_of_blocks(atomf)%no_of_part(iblock) > 0) !naba atoms?
     enddo ! iblock : primary set of blocks
     deallocate(temp_block_storage)
-    !#!!$omp end parallel do
     call my_barrier()
     call start_timer(tmr_std_allocation)
     deallocate(ip_store,x_store,y_store,z_store,r_store)

--- a/src/system.make
+++ b/src/system.make
@@ -4,41 +4,30 @@
 FC=mpif90
 F77=mpif77
 
+# OpenMP flags
+OMPFLAGS= -fopenmp
+
 # Linking flags
-LINKFLAGS= -L/usr/local/lib
+LINKFLAGS=  -L${MKLROOT}/lib/intel64 -lmkl_scalapack_lp64 -lmkl_cdft_core -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -lmkl_blacs_intelmpi_lp64 -liomp5 -lpthread -ldl $(OMPFLAGS) $(XC_LIB)
 ARFLAGS=
 
 # Compilation flags
 # NB for gcc10 you need to add -fallow-argument-mismatch
-COMPFLAGS= -O3 $(XC_COMPFLAGS)
+COMPFLAGS= -g -O2 $(OMPFLAGS) $(XC_COMPFLAGS) -I"${MKLROOT}/include"
 COMPFLAGS_F77= $(COMPFLAGS)
-
-# Set BLAS and LAPACK libraries
-# MacOS X
-# BLAS= -lvecLibFort
-# Intel MKL use the Intel tool
-# Generic
-# BLAS= -llapack -lblas
-
-# Full library call; remove scalapack if using dummy diag module
-LIBS= $(FFT_LIB) $(XC_LIB) -lscalapack $(BLAS)
-
-# LibXC compatibility (LibXC below) or Conquest XC library
-
-# Conquest XC library
-#XC_LIBRARY = CQ
-#XC_LIB =
-#XC_COMPFLAGS =
 
 # LibXC compatibility
 # Choose LibXC version: v4 or v5
 XC_LIBRARY = LibXC_v4
-# XC_LIBRARY = LibXC_v5
-XC_LIB = -lxcf90 -lxc
-XC_COMPFLAGS = -I/usr/local/include
+XC_LIB = -L/shared/ucl/apps/libxc/4.2.3/intel-2018/lib -lxcf90 -lxc
+XC_COMPFLAGS = -I/shared/ucl/apps/libxc/4.2.3/intel-2018/include
+
+#XC_LIBRARY = LibXC_v5
+#XC_LIB = -L/home/cceaosk/libxc-5.2.3/install/lib64/ -lxc -lxcf90
+#XC_COMPFLAGS = -I/home/cceaosk/libxc-5.2.3/install/include/
 
 # Set FFT library
-FFT_LIB=-lfftw3
+FFT_LIB=-lmkl_rt
 FFT_OBJ=fft_fftw3.o
 
 # Matrix multiplication kernel type
@@ -46,4 +35,6 @@ MULT_KERN = default
 # Use dummy DiagModule or not
 DIAG_DUMMY =
 
+# Full library call; remove scalapack if using dummy diag module
+LIBS= $(FFT_LIB) $(XC_LIB)
 


### PR DESCRIPTION
The no_of_ib_ia variable is determined within the loop and isn't thread-safe (as far as I can see) so I've moved the OpenMP loop further in which in my tests is actually slower with multi-threading though I can't see why!

This is only a demonstration, not code to be merged or used in production