### PR TITLE
PP: Add Fermi_offset

### DIFF
--- a/tools/PostProcessing/stm_module.f90
+++ b/tools/PostProcessing/stm_module.f90
@@ -349,6 +349,8 @@ contains
     allocate(current(nptsx,nptsy,nptsz))
     allocate(psi(nptsx,nptsy,nptsz))
 
+    if (nspin==1 .and. fermi_offset.ne.zero) &
+       write(*,fmt='(2X,"Fermi-offset is ",f7.3," eV")') fermi_offset
     fermi_offset = fermi_offset/HaToeV   ! default of fermi_offset is zero
     if(stm_bias<0) then
        Emin = stm_bias/HaToeV + Efermi + fermi_offset

--- a/tools/PostProcessing/stm_module.f90
+++ b/tools/PostProcessing/stm_module.f90
@@ -349,8 +349,7 @@ contains
     allocate(current(nptsx,nptsy,nptsz))
     allocate(psi(nptsx,nptsy,nptsz))
 
-    if (nspin==1 .and. fermi_offset.ne.zero) &
-       write(*,fmt='(2X,"Fermi-offset is ",f7.3," eV")') fermi_offset
+    if (fermi_offset.ne.zero) write(*,fmt='(2X,"Fermi-offset is ",f7.3," eV")') fermi_offset
     fermi_offset = fermi_offset/HaToeV   ! default of fermi_offset is zero
     if(stm_bias<0) then
        Emin = stm_bias/HaToeV + Efermi + fermi_offset

--- a/tools/PostProcessing/stm_module.f90
+++ b/tools/PostProcessing/stm_module.f90
@@ -349,7 +349,7 @@ contains
     allocate(current(nptsx,nptsy,nptsz))
     allocate(psi(nptsx,nptsy,nptsz))
 
-    if (fermi_offset.ne.zero) write(*,fmt='(2X,"Fermi-offset is ",f7.3," eV")') fermi_offset
+    if (fermi_offset.ne.zero) write(*,fmt='(2X,"Fermi-offset is ",f10.3," eV")') fermi_offset
     fermi_offset = fermi_offset/HaToeV   ! default of fermi_offset is zero
     if(stm_bias<0) then
        Emin = stm_bias/HaToeV + Efermi + fermi_offset
@@ -359,7 +359,7 @@ contains
        Emax = stm_bias/HaToeV + Efermi + fermi_offset
     end if
     if(nspin==1) then
-       write(*,fmt='(2x,"Including bands between ",f7.3," and ",f7.3," eV")') Emin(1)*HaToeV, Emax(1)*HaToeV
+       write(*,fmt='(2x,"Including bands between ",f10.3," and ",f10.3," eV")') Emin(1)*HaToeV, Emax(1)*HaToeV
     end if
 
     current = zero

--- a/tools/PostProcessing/stm_module.f90
+++ b/tools/PostProcessing/stm_module.f90
@@ -321,7 +321,7 @@ contains
 
     use datatypes
     use numbers
-    use local, ONLY: nkp, wtk, efermi, current, nptsx, nptsy, nptsz, eigenvalues, stm_bias, &
+    use local, ONLY: nkp, wtk, efermi, current, nptsx, nptsy, nptsz, eigenvalues, stm_bias, fermi_offset, &
          n_bands_total, root_file, grid_z, band_full_to_active
     use output, ONLY: write_dx_density, write_cube, write_dx_coords
     use global_module, only : nspin
@@ -348,16 +348,19 @@ contains
     call set_prefac_real(9)
     allocate(current(nptsx,nptsy,nptsz))
     allocate(psi(nptsx,nptsy,nptsz))
+
+    fermi_offset = fermi_offset/HaToeV   ! default of fermi_offset is zero
     if(stm_bias<0) then
-       Emin = stm_bias/HaToeV + Efermi
-       Emax = Efermi
+       Emin = stm_bias/HaToeV + Efermi + fermi_offset
+       Emax = Efermi + fermi_offset
     else
-       Emin = Efermi
-       Emax = stm_bias/HaToeV + Efermi
+       Emin = Efermi + fermi_offset
+       Emax = stm_bias/HaToeV + Efermi + fermi_offset
     end if
     if(nspin==1) then
        write(*,fmt='(2x,"Including bands between ",f7.3," and ",f7.3," eV")') Emin(1)*HaToeV, Emax(1)*HaToeV
     end if
+
     current = zero
     do ispin=1,nspin
        do band=1,n_bands_total


### PR DESCRIPTION
"fermi_offset" can be read as 'STM.FermiOffset' in Conquest_input
but was never used in the code.
The code has been modified to add fermi_offset to Emin and Emax in stm_module.f90.

This branch is related to issue #208 .