### PR TITLE
PP: Added output of Efermi in eV unit

### DIFF
--- a/tools/PostProcessing/read_module.f90
+++ b/tools/PostProcessing/read_module.f90
@@ -458,10 +458,10 @@ contains
     efermi = zero
     if(nspin==1) then
        read(17,fmt='(a6,f18.10)') str,efermi(1)
-       write(*,fmt='(4x,"Fermi level: ",f12.5," Ha   (=",f7.3," eV)")') efermi(1), efermi(1)*HaToeV
+       write(*,fmt='(4x,"Fermi level: ",f12.5," Ha   (=",f10.3," eV)")') efermi(1), efermi(1)*HaToeV
     else
        read(17,fmt='(a6,2f18.10)') str,efermi(1), efermi(2)
-       write(*,fmt='(4x,"Fermi levels: ",2f12.5," Ha   (=",2f7.3" eV)")') efermi, efermi*HaToeV
+       write(*,fmt='(4x,"Fermi levels: ",2f12.5," Ha   (=",2f10.3" eV)")') efermi, efermi*HaToeV
     end if
     read(17,*) str
     ! Allocate memory

--- a/tools/PostProcessing/read_module.f90
+++ b/tools/PostProcessing/read_module.f90
@@ -458,10 +458,10 @@ contains
     efermi = zero
     if(nspin==1) then
        read(17,fmt='(a6,f18.10)') str,efermi(1)
-       write(*,fmt='(4x,"Fermi level: ",f12.5," Ha")') efermi(1)
+       write(*,fmt='(4x,"Fermi level: ",f12.5," Ha   (=",f7.3," eV)")') efermi(1), efermi(1)*HaToeV
     else
        read(17,fmt='(a6,2f18.10)') str,efermi(1), efermi(2)
-       write(*,fmt='(4x,"Fermi levels: ",2f12.5," Ha")') efermi
+       write(*,fmt='(4x,"Fermi levels: ",2f12.5," Ha   (=",2f7.3" eV)")') efermi, efermi*HaToeV
     end if
     read(17,*) str
     ! Allocate memory


### PR DESCRIPTION
In Conquest_out of PostProcessing, Efermi is written only in Hartree unit,
while the energy range of STM is written in eV.

So for easy comparison with the energy range, Efermi in eV unit has been added in Conquest_out.

This is related to issue #209 .