### PR TITLE
Fixed problems with non-SCF forces and structural optimisation

### DIFF
--- a/src/force_module.f90
+++ b/src/force_module.f90
@@ -3412,6 +3412,8 @@ contains
   !!    Added atomic stress contributions
   !!   2021/03/23 15:52 dave
   !!    Bugfix: correct calculation of rsq implemented, variables tidied
+  !!   2023/07/19 10:40 dave
+  !!    Added minus sign to non-SCF PCC force for consistency with non-SCF part
   !!  SOURCE
   !!
   subroutine get_nonSC_correction_force(HF_force, density_out, inode, &
@@ -3962,7 +3964,8 @@ contains
                                   ! calculated from set_density
                                   do spin = 1, nspin
                                      do dir1 = 1, 3
-                                        fr_pcc(dir1,spin) = r_pcc(dir1) * half * derivative_pcc * density_scale(spin)
+                                        fr_pcc(dir1,spin) = -r_pcc(dir1) * half * &
+                                             derivative_pcc * density_scale(spin)
                                      end do
                                   end do
                                end if

--- a/src/move_atoms.module.f90
+++ b/src/move_atoms.module.f90
@@ -3775,7 +3775,7 @@ contains
        if (.not.flag_LFD_MD_UseAtomicDensity) call set_atomic_density(.false.)
     end if
     ! If we have read K and are predicting density from it, then rebuild
-    if(flag_diagonalisation.AND.flag_LmatrixReuse) then
+    if(flag_diagonalisation.AND.flag_LmatrixReuse.AND.flag_self_consistent) then
        call get_electronic_density(density,electrons,atomfns,H_on_atomfns(1), &
             inode,ionode,maxngrid)
        do spin=1,nspin


### PR DESCRIPTION
There was a missing minus sign in the PCC part of the non-SCF forces, and a missing non-SCF exception when rebuilding the charge density from the DM after atomic movement.

With this change, non-SCF forces are correct, and non-SCF stress is correct for the non-neutral-atom case (another fix is needed for that!).

Fixes #118 