### PR TITLE
Pull request to proj_PadHamiltonianMatrix (should work with a given block size)

### DIFF
--- a/src/DiagModule.f90
+++ b/src/DiagModule.f90
@@ -2136,12 +2136,8 @@ contains
                    ! localEig(Distrib%firstrow(recv_proc+1)+j-1,coff:coff+block_size_c-1) = RecvBuffer(j,k:k+block_size_c-1)
 
                    if(coff+block_size_c-1 > matrix_size) then 
-                    !TMP localEig(coff:matrix_size,Distrib%firstrow(recv_proc+1)+j-1) = RecvBuffer(j,k:k+block_size_c-1)
-         
-                    do l=1, block_size_c
-                      if( coff+l-1 > matrix_size ) cycle
-                      localEig(coff+l-1,Distrib%firstrow(recv_proc+1)+j-1) = RecvBuffer(j,k+l-1)
-                    end do
+                     !coff+l-1 = matrix_size  => l = matrix_size+1-coff
+                     localEig(coff:matrix_size,Distrib%firstrow(recv_proc+1)+j-1) = RecvBuffer(j,k:k+matrix_size-coff)
                    else
                     localEig(coff:coff+block_size_c-1,Distrib%firstrow(recv_proc+1)+j-1) = RecvBuffer(j,k:k+block_size_c-1)
                    endif
@@ -2197,10 +2193,8 @@ contains
                            Distrib%firstrow(recv_proc+1),RecvBuffer(j,k)
                       !localEig(Distrib%firstrow(recv_proc+1)+j-1,coff:coff+block_size_c-1) = RecvBuffer(j,k:k+block_size_c-1)
                       if(coff+block_size_c -1 > matrix_size) then
-                       do l=1, block_size_c
-                         if( coff+l-1 > matrix_size ) cycle
-                         localEig(coff+l-1,Distrib%firstrow(recv_proc+1)+j-1) = RecvBuffer(j,k+l-1)
-                       end do
+                       !coff+l-1 = matrix_size  => l = matrix_size+1-coff
+                       localEig(coff:matrix_size,Distrib%firstrow(recv_proc+1)+j-1) = RecvBuffer(j,k:k+matrix_size-coff)
                       else
                        localEig(coff:coff+block_size_c-1,Distrib%firstrow(recv_proc+1)+j-1) = &
                             RecvBuffer(j,k:k+block_size_c-1)

--- a/src/ScalapackFormat.f90
+++ b/src/ScalapackFormat.f90
@@ -284,6 +284,7 @@ contains
      blocks_c = (matrix_size/block_size_c)
      matrix_size_padH = matrix_size
     endif
+    if(myid==0.AND.iprint_DM>3) write(io_lun,*) "matrix_size & matrix_size_padH = ",matrix_size, matrix_size_padH
     if(myid==0.AND.iprint_DM>3) write(io_lun,1) blocks_r,blocks_c
     maxrow = floor(real(blocks_r/proc_rows))+1
     maxcol = floor(real(blocks_c/proc_cols))+1
@@ -1004,6 +1005,9 @@ contains
 
     ! for padding H matrix, we need to initialise SC_col_block_atom
           SC_col_block_atom(:,:)%part = 0
+     ! for safety other members are also initialised.
+          SC_col_block_atom(:,:)%atom = 0
+          SC_col_block_atom(:,:)%support_fn = 0
          
     if(iprint_DM>3.AND.myid==0) write(io_lun,fmt='(10x,i5, a)') myid,' Starting Find SC Col Atoms'
     ! Loop over SC blocks
@@ -1013,7 +1017,7 @@ contains
        do blockcol = 1,block_size_c
           part = ref_col_block_atom(blockcol,refc)%part  
           ! for the padded part (padding Hmatrix version)
-          if(part == 0) cycle
+          if(part == 0) cycle    ! for padding H and S matrices  (for padded part)
           seq  = ref_col_block_atom(blockcol,refc)%atom  
           supfn  = ref_col_block_atom(blockcol,refc)%support_fn
           SC_col_block_atom(blockcol,cb)%part = part


### PR DESCRIPTION
I have not checked many examples, but I would like to create a pull request to the branch (proj_PadHamiltonianMatrix). 
For my test systems, I have confirmed that this version correctly runs with a given block size provided in Conquest_input.
I think this version should be already very useful, since it should improve the efficiency of CONQUEST dramatically in some cases. (especially when the size of Hamiltonian or Overlap matrix is a prime number)
At present, I assume that users will provide the block size by theirselves. 

1. I have not considered the case for the small size of matrix.   (when block size ~ matrix size)
2. I have not checked whether the code works for multiple k-points, with `Diag.KProcGroups` more than 1.
3. I have not followed how (# of proc rows) and (# of proc cols) are determined automatically in the present version of the code yet. 
4. It is probably necessary to have a default block size, which needs to be automatically set from the number of MPI processes and matrix size.

All of these problems will be discussed in another issue. 