### PR TITLE
Fix non-NA and non-SCF stress issues

### DIFF
--- a/docs/input_tags.rst
+++ b/docs/input_tags.rst
@@ -1403,6 +1403,16 @@ General.GapThreshold (*real*)
 General.only_Dispersion (*boolean*)
     Selects only DFT\_D2 calculation (no electronic structure etc)
 
+General.MixXCGGAInOut (*real*)
+    For non-SCF calculations only, chooses how to mix the proportions of
+    GGA XC stress contribution (from the change of the electron density
+    gradient) found using input (0.0 gives pure input) and output (1.0
+    gives pure output) densities.  Note that this is an approximation but
+    varying the value significantly away from 0.5 will give inconsistency
+    between stress and energy.
+
+    *default*: 0.5
+    
 Go to :ref:`top <input_tags>`.
 
 .. _advanced_atomic_spec_tags:

--- a/src/XC_CQ_module.f90
+++ b/src/XC_CQ_module.f90
@@ -229,6 +229,7 @@ contains
     ! Local variables
     real(double) :: loc_x_energy, exx_tmp
 
+    XC_GGA_stress = zero
     select case(flag_functional_type)
     case (functional_lda_pz81)
        ! NOT SPIN POLARISED

--- a/src/XC_LibXC_v4_module.f90
+++ b/src/XC_LibXC_v4_module.f90
@@ -366,6 +366,7 @@ contains
     ! Local variables
     real(double) :: loc_x_energy, exx_tmp
 
+    XC_GGA_stress = zero
     if(flag_use_libxc) then
        call get_libxc_potential(density=density, size=size,&
             xc_potential    =xc_potential,    &

--- a/src/XC_LibXC_v5_module.f90
+++ b/src/XC_LibXC_v5_module.f90
@@ -370,6 +370,7 @@ contains
     ! Local variables
     real(double) :: loc_x_energy, exx_tmp
 
+    XC_GGA_stress = zero
     if(flag_use_libxc) then
        call get_libxc_potential(density=density, size=size,&
             xc_potential    =xc_potential,    &

--- a/src/initial_read_module.f90
+++ b/src/initial_read_module.f90
@@ -941,6 +941,7 @@ contains
     use biblio, only: flag_dump_bib
     !2019/12/27 tsuyoshi
     use density_module,  only: method_UpdateChargeDensity,DensityMatrix,AtomicCharge
+    use force_module, only: mix_input_output_XC_GGA_stress
 
     implicit none
 
@@ -1572,6 +1573,10 @@ contains
     sqnm_trust_step       = fdf_double ('AtomMove.MaxSQNMStep',0.2_double   )
     LBFGS_history         = fdf_integer('AtomMove.LBFGSHistory', 5          )
     flag_opt_cell         = fdf_boolean('AtomMove.OptCell',          .false.)
+    ! At present (2023/07/26 just before v1.2 release) neutral atom is required for cell opt
+    if(flag_opt_cell.and.(.not.flag_neutral_atom)) &
+         call cq_abort("You must use neutral atom for cell optimisation")
+    ! This can be removed when ewald update is implemented
     flag_variable_cell    = flag_opt_cell
     optcell_method        = fdf_integer('AtomMove.OptCellMethod', 1)
     cell_constraint_flag  = fdf_string(20,'AtomMove.OptCell.Constraint','none')
@@ -1583,6 +1588,7 @@ contains
     flag_stress           = fdf_boolean('AtomMove.CalcStress', .true.)
     flag_full_stress      = fdf_boolean('AtomMove.FullStress', .false.)
     flag_atomic_stress    = fdf_boolean('AtomMove.AtomicStress', .false.)
+    mix_input_output_XC_GGA_stress = fdf_double('General.MixXCGGAInOut',half)
     !
     flag_vary_basis       = fdf_boolean('minE.VaryBasis', .false.)
     if(.NOT.flag_vary_basis) then


### PR DESCRIPTION
This fixes issues in stress calculations for non-SCF calculations and calculations where the neutral atom (NA) potential is *not* used.

Note that for non-SCF calculations with GGA there is an approximation relating to the stress that comes from the change of XC energy with gradient of the charge density.  Strictly speaking, this should be calculated from a mixture of input and output densities, but the resulting formulae and code will be very complicated.  For now, we take a mixture of the stress calculated with input density and the stress calculated with output density; this approximation is accurate to better than 0.1GPa in all tests, and is certainly better than the existing calculation using just input density.