### PR TITLE
Bug(?) in the if-statement before calling dump_pos_and_matrices

### DIFF
--- a/src/DMMinModule.f90
+++ b/src/DMMinModule.f90
@@ -1235,8 +1235,8 @@ contains
        end if
 
        ! dump the L matrix if required
-       if (n_dumpL>0 .and. mod (n_iter, n_dumpL) == 0) then
-           call dump_pos_and_matrices(index=unit_DM_save)
+       if (n_dumpL>0) then
+          if(mod (n_iter, n_dumpL) == 0) call dump_pos_and_matrices(index=unit_DM_save)
        endif
        !if (flag_dump_L) then
        !   if (mod (n_iter, n_dumpL) == 0) then

--- a/src/SelfCon_module.f90
+++ b/src/SelfCon_module.f90
@@ -1207,8 +1207,8 @@ contains
 
        ! 2019Dec30 tsuyoshi
        ! Dump Kmatrix every n_dumpSCF, if n_dumpSCF > 0
-       if(n_dumpSCF > 0 .and. mod(n_iters,n_dumpSCF)==0) then
-        call dump_pos_and_matrices(index=unit_SCF_save)
+       if(n_dumpSCF > 0) then 
+        if(mod(n_iters,n_dumpSCF)==0) call dump_pos_and_matrices(index=unit_SCF_save)
        endif
 
        ! increment iteration counter

--- a/src/pao_minimisation.module.f90
+++ b/src/pao_minimisation.module.f90
@@ -558,8 +558,8 @@ contains
        !enddo
 
        ! Write out current SF coefficients every n_dumpSFcoeff, if n_dumpSFcoeff > 0)
-       if (n_dumpSFcoeff > 0 .and. mod(n_iterations,n_dumpSFcoeff) == 0) then
-          call dump_pos_and_matrices(index = unit_MSSF_save)
+       if (n_dumpSFcoeff > 0) then
+          if(mod(n_iterations,n_dumpSFcoeff) == 0) call dump_pos_and_matrices(index = unit_MSSF_save)
        endif
 
        ! Find change in energy for convergence
@@ -1181,8 +1181,8 @@ contains
        endif
 
        ! Write out current SF coefficients and density matrices with some iprint (in future)
-       if(n_dumpSFcoeff > 0 .and. mod(iter,n_dumpSFcoeff) ==0) then
-          call dump_pos_and_matrices(index=unit_MSSF_save)
+       if(n_dumpSFcoeff > 0 ) then
+          if(mod(iter,n_dumpSFcoeff) ==0) call dump_pos_and_matrices(index=unit_MSSF_save)
        endif
        ! Go out if converged
        if (convergence_flag) then


### PR DESCRIPTION
It may not be a bug, but ..
after I updated the MacOS, I encountered a problem in the following part with the option (-O3).

if (n_dumpL>0 .and. mod (n_iter, n_dumpL) == 0) then 
 call dump_pos_and_matrices(index=unit_DM_save)
endif

The problem seems to come from the 2nd one when n_dumpL=0. I thought it is not used since we also checked n_dumpL. But, it is probably safer to change it to

if (n_dumpL>0) then
 if(mod (n_iter, n_dumpL) == 0) call dump_pos_and_matrices(index=unit_DM_save) 
endif