### PR TITLE
Implement WF output with phases

### DIFF
--- a/tools/PostProcessing/local_module.f90
+++ b/tools/PostProcessing/local_module.f90
@@ -37,6 +37,7 @@ module local
   integer :: flag_proc_band_str
   logical :: flag_only_charge, flag_by_kpoint, flag_wf_range, flag_proc_range, flag_procwf_range_Ef
   logical :: flag_total_iDOS, flag_write_forces, flag_write_spin_moments, flag_l_resolved, flag_lm_resolved
+  logical :: flag_outputWF_real
   character(len=80) :: charge_stub
 
   integer :: i_job ! Job type

--- a/tools/PostProcessing/read_module.f90
+++ b/tools/PostProcessing/read_module.f90
@@ -255,6 +255,9 @@ contains
        stop
     end if
     flag_by_kpoint = fdf_boolean('Process.outputWF_by_kpoint',.false.)
+    ! if output only the real part of WFs (for Gamma-point only)
+    flag_outputWF_real = .false.
+    if (leqi(job,'ban')) flag_outputWF_real = fdf_boolean('Process.outputWF_real',.false.)
     ! DOS
     ! Add flag for window relative to Fermi level
     E_DOS_min = fdf_double('Process.min_DOS_E',E_wf_min)


### PR DESCRIPTION
It is sometimes needed to draw molecular orbital (MO) pictures with phases, 
not the squared values, i.e., the orbital densities.

With the input flag
Process.Job ban
and 
Process.outputWF_real T
, the MO cube files will be made by the PostProcessing tool.

This is available only for Gamma-point calculations, 
because MO cube files have physical meaning only for Gamma-point-only calculations.