### PR TITLE
Improve threading in PAO_grid_transform_module

### DIFF
--- a/src/PAO_grid_transform_module.f90
+++ b/src/PAO_grid_transform_module.f90
@@ -234,13 +234,12 @@ contains
                       y = y_store(ip)
                       z = z_store(ip)
                       ! For this point-atom offset, we accumulate the PAO on the grid
-                      count1 = 0
                       l_loop: do l1 = 0,pao(my_species)%greatest_angmom
                          z_loop: do acz = 1,pao(my_species)%angmom(l1)%n_zeta_in_angmom
                             m_loop: do m1=-l1,l1
                                call evaluate_pao(my_species,l1,acz,m1,x,y,z,val)
-                               gridfunctions(pao_fns)%griddata(position + count1 * n_pts_in_block) = val
-                               count1 = count1+1
+                               gridfunctions(pao_fns)%griddata(position) = val
+                               position = position + n_pts_in_block
                             end do m_loop
                          end do z_loop
                       end do l_loop

--- a/src/PAO_grid_transform_module.f90
+++ b/src/PAO_grid_transform_module.f90
@@ -175,7 +175,6 @@ contains
     call my_barrier()
 
     gridfunctions(pao_fns)%griddata = zero
-
     next_offset_position = 0
     offset_position = huge(0)
     rcut = r_h + RD_ERR
@@ -243,15 +242,15 @@ contains
                       z = z_store(ip, ia, ipart, iblock)
                       ! For this point-atom offset, we accumulate the PAO on the grid
                       count1 = 1
-                      l: do l1 = 0,pao(the_species(ia, ipart, iblock))%greatest_angmom
-                         zeta: do acz = 1,pao(the_species(ia, ipart, iblock))%angmom(l1)%n_zeta_in_angmom
-                            m: do m1=-l1,l1
+                      l_loop: do l1 = 0,pao(the_species(ia, ipart, iblock))%greatest_angmom
+                         z_loop: do acz = 1,pao(the_species(ia, ipart, iblock))%angmom(l1)%n_zeta_in_angmom
+                            m_loop: do m1=-l1,l1
                                call evaluate_pao(the_species(ia, ipart, iblock),l1,acz,m1,x,y,z,val)
                                gridfunctions(pao_fns)%griddata(position+(count1-1)*n_pts_in_block) = val
                                count1 = count1+1
-                            end do m
-                         end do zeta
-                      end do l
+                            end do m_loop
+                         end do z_loop
+                      end do l_loop
                    enddo points_loop_omp
                 endif npoint_if_omp
              enddo atoms_loop_omp
@@ -261,7 +260,7 @@ contains
     !$omp end parallel do
     call my_barrier()
     call start_timer(tmr_std_allocation)
-    deallocate(ip_store,x_store,y_store,z_store,r_store)
+    deallocate(ip_store,x_store,y_store,z_store,r_store,the_species,offset_position,npoint)
     call stop_timer(tmr_std_allocation)
     call stop_timer(tmr_std_basis)
     return

--- a/src/PAO_grid_transform_module.f90
+++ b/src/PAO_grid_transform_module.f90
@@ -141,7 +141,6 @@ contains
     real(double) :: rcut
     real(double) :: r1, r2, r3, r4, core_charge, gauss_charge
     real(double) :: val, theta, phi, r_tmp
-    integer :: max_num_blocks, current_num_blocks
     real(double), dimension(:), allocatable :: temp_block_storage
 
     integer :: next_offset_position
@@ -213,18 +212,18 @@ contains
                      z_store( :, ia, ipart, iblock), & !out
                      n_pts_in_block) ! in
 
-                npoint_if: if (npoint(ia, ipart, iblock) > 0) then
+                if (npoint(ia, ipart, iblock) > 0) then
                    offset_position(ia, ipart, iblock) = next_offset_position
-                   current_num_blocks = npao_species(the_species(ia, ipart, iblock)) * n_pts_in_block
-                   next_offset_position = offset_position(ia, ipart, iblock) + current_num_blocks
-                end if npoint_if
+                end if
+                next_offset_position = next_offset_position + &
+                     npao_species(the_species(ia, ipart, iblock)) * n_pts_in_block
              end do atoms_loop
           end do parts_loop
        end if part_in_block
     end do blocks_loop
 
     !$omp parallel do default(none) &
-    !$omp             schedule(dynamic) &
+    !$omp             schedule(static) &
     !$omp             shared(domain, naba_atoms_of_blocks, npoint, offset_position, pao_fns, atomf, &
     !$omp                    x_store, y_store, z_store, ip_store, pao, gridfunctions, the_species, &
     !$omp                    n_pts_in_block) &

--- a/src/PAO_grid_transform_module.f90
+++ b/src/PAO_grid_transform_module.f90
@@ -7,7 +7,7 @@
 ! Code area 11: basis operations
 ! ------------------------------------------------------------------------------
 
-!!****h* Conquest/PAO_grid_transform_module * 
+!!****h* Conquest/PAO_grid_transform_module *
 !!  NAME
 !!   PAO_grid_transform_module
 !!  PURPOSE
@@ -19,11 +19,11 @@
 !!  AUTHOR
 !!   D.R.Bowler
 !!  CREATION DATE
-!!   16:37, 2003/09/22 
+!!   16:37, 2003/09/22
 !!  MODIFICATION HISTORY
 !!   2005/07/11 10:18 dave
 !!    Tidied up use statements (only one occurence) for ifort
-!!   10:31, 13/02/2006 drb 
+!!   10:31, 13/02/2006 drb
 !!    Changed lines to conform to F90 standard
 !!   2006/06/20 08:15 dave
 !!    Various changes for variable NSF
@@ -56,18 +56,18 @@ contains
 
 !!****f* PAO_grid_transform_module/single_PAO_to_grid *
 !!
-!!  NAME 
+!!  NAME
 !!   single_PAO_to_grid
 !!  USAGE
-!! 
+!!
 !!  PURPOSE
 !!   Projects the PAO functions onto the grid (rather than support functions)
 !!   Used for gradients of energy wrt PAO coefficients
 !!  INPUTS
-!! 
-!! 
+!!
+!!
 !!  USES
-!! 
+!!
 !!  AUTHOR
 !!   D. R. Bowler
 !!  CREATION DATE
@@ -115,7 +115,7 @@ contains
     use functions_on_grid, ONLY: gridfunctions, fn_on_grid
     use pao_format
 
-    implicit none 
+    implicit none
     integer,intent(in) :: pao_fns
 
     !local
@@ -123,19 +123,19 @@ contains
     integer :: ipart,jpart,ind_part,ia,ii,icover,ig_atom
     real(double):: xatom,yatom,zatom,alpha,step
     real(double):: xblock,yblock,zblock
-    integer :: the_species
     integer :: j,iblock,the_l,ipoint, igrid
     real(double) :: r_from_i
     real(double) :: rr,a,b,c,d,x,y,z,nl_potential
-    integer :: no_of_ib_ia, offset_position
     integer :: position,iatom
-    integer :: stat, nl, npoint, ip, this_nsf
+    integer :: stat, nl, ip, this_nsf
     integer :: i,m, m1min, m1max,acz,m1,l1,count1
-    integer     , allocatable :: ip_store(:)
-    real(double), allocatable :: x_store(:)
-    real(double), allocatable :: y_store(:)
-    real(double), allocatable :: z_store(:)
-    real(double), allocatable :: r_store(:)
+    integer     , allocatable :: the_species(:,:,:)
+    integer     , allocatable :: npoint(:,:,:)
+    integer     , allocatable :: ip_store(:,:,:,:)
+    real(double), allocatable :: x_store(:,:,:,:)
+    real(double), allocatable :: y_store(:,:,:,:)
+    real(double), allocatable :: z_store(:,:,:,:)
+    real(double), allocatable :: r_store(:,:,:,:)
     real(double) :: coulomb_energy
     real(double) :: rcut
     real(double) :: r1, r2, r3, r4, core_charge, gauss_charge
@@ -143,38 +143,56 @@ contains
     integer :: max_num_blocks, current_num_blocks
     real(double), dimension(:), allocatable :: temp_block_storage
 
+    integer :: next_offset_position
+    integer, allocatable :: offset_position(:,:,:)
+
+    integer :: nblock, npart, natom
+
+    nblock = domain%groups_on_node
+    npart = maxval(naba_atoms_of_blocks(atomf)%no_of_part)
+    natom = maxval(naba_atoms_of_blocks(atomf)%no_atom_on_part)
+
     call start_timer(tmr_std_basis)
     call start_timer(tmr_std_allocation)
-    allocate(ip_store(n_pts_in_block),x_store(n_pts_in_block),y_store(n_pts_in_block),z_store(n_pts_in_block), &
-         r_store(n_pts_in_block))
+    allocate(ip_store(n_pts_in_block, natom, npart, nblock))
+    allocate(x_store(n_pts_in_block, natom, npart, nblock))
+    allocate(y_store(n_pts_in_block, natom, npart, nblock))
+    allocate(z_store(n_pts_in_block, natom, npart, nblock))
+    allocate(r_store(n_pts_in_block, natom, npart, nblock))
+    allocate(the_species(natom, npart, nblock))
+    allocate(offset_position(natom, npart, nblock))
+    allocate(npoint(natom, npart, nblock))
     call stop_timer(tmr_std_allocation)
     ! --  Start of subroutine  ---
 
+    ! No need to compute these here, since they are derived from globals
+    ! Store with rcellx, rcelly, rcellz?
+    ! Reduces code duplication
     dcellx_block=rcellx/blocks%ngcellx
     dcelly_block=rcelly/blocks%ngcelly
     dcellz_block=rcellz/blocks%ngcellz
 
     call my_barrier()
 
-    no_of_ib_ia = 0
     gridfunctions(pao_fns)%griddata = zero
 
-    max_num_blocks = maxval(npao_species)*n_pts_in_block
-    allocate(temp_block_storage(max_num_blocks))
-    
+    next_offset_position = 0
+    offset_position = huge(0)
+    rcut = r_h + RD_ERR
+
     ! loop arround grid points in the domain, and for each
     ! point, get the PAO values
 
-    do iblock = 1, domain%groups_on_node ! primary set of blocks
+    blocks_loop: do iblock = 1, domain%groups_on_node ! primary set of blocks
        xblock=(domain%idisp_primx(iblock)+domain%nx_origin-1)*dcellx_block
        yblock=(domain%idisp_primy(iblock)+domain%ny_origin-1)*dcelly_block
        zblock=(domain%idisp_primz(iblock)+domain%nz_origin-1)*dcellz_block
-       if(naba_atoms_of_blocks(atomf)%no_of_part(iblock) > 0) then ! if there are naba atoms
+       part_in_block: if(naba_atoms_of_blocks(atomf)%no_of_part(iblock) > 0) then ! if there are naba atoms
           iatom=0
-          do ipart=1,naba_atoms_of_blocks(atomf)%no_of_part(iblock)
+          parts_loop: do ipart=1,naba_atoms_of_blocks(atomf)%no_of_part(iblock)
              jpart=naba_atoms_of_blocks(atomf)%list_part(ipart,iblock)
              ind_part=DCS_parts%lab_cell(jpart)
-             do ia=1,naba_atoms_of_blocks(atomf)%no_atom_on_part(ipart,iblock)
+             atoms_loop: do ia=1,naba_atoms_of_blocks(atomf)%no_atom_on_part(ipart,iblock)
                 iatom=iatom+1
                 ii = naba_atoms_of_blocks(atomf)%list_atom(iatom,iblock)
                 icover= DCS_parts%icover_ibeg(jpart)+ii-1
@@ -183,56 +201,64 @@ contains
                 xatom=DCS_parts%xcover(icover)
                 yatom=DCS_parts%ycover(icover)
                 zatom=DCS_parts%zcover(icover)
-                the_species=species_glob(ig_atom)
+                the_species(ia, ipart, iblock)=species_glob(ig_atom)
 
                 !calculates distances between the atom and integration grid points
                 !in the block and stores which integration grids are neighbours.
-                rcut = r_h + RD_ERR
                 call check_block (xblock,yblock,zblock,xatom,yatom,zatom, rcut, &  ! in
-                     npoint,ip_store,r_store,x_store,y_store,z_store,n_pts_in_block) !out
+                     npoint(ia, ipart, iblock), & !out
+                     ip_store(:,ia, ipart, iblock), & !out
+                     r_store(:,ia, ipart, iblock), & !out *Note: Does not seem to get used
+                     x_store(:,ia, ipart, iblock), & !out
+                     y_store(:,ia, ipart, iblock), & !out
+                     z_store(:,ia, ipart, iblock), & !out
+                     n_pts_in_block) ! in
 
-                if(npoint > 0) then
-                   current_num_blocks = npao_species(the_species)*n_pts_in_block
-                   temp_block_storage = zero
-                   offset_position = no_of_ib_ia
-                   !$omp parallel do default(none) &
-                   !$omp             schedule(dynamic) &
-                   !$omp             reduction(+: temp_block_storage) &
-                   !$omp             shared(n_pts_in_block, pao, the_species, offset_position, &
-                   !$omp                    npoint, no_of_ib_ia, ip_store, r_store, x_store, y_store, z_store) &
-                   !$omp             private(r_from_i, ip, position, ipoint, &
-                   !$omp                     x, y, z, l1, acz, m1, count1, val)
-                   do ip=1,npoint
-                      ipoint=ip_store(ip)
-                      position= offset_position + ipoint
+                npoint_if: if (npoint(ia, ipart, iblock) > 0) then
+                   offset_position(ia, ipart, iblock) = next_offset_position
+                   current_num_blocks = npao_species(the_species(ia, ipart, iblock)) * n_pts_in_block
+                   next_offset_position = offset_position(ia, ipart, iblock) + current_num_blocks
+                end if npoint_if
+             end do atoms_loop
+          end do parts_loop
+       end if part_in_block
+    end do blocks_loop
 
-                      r_from_i = r_store(ip)
-                      x = x_store(ip)
-                      y = y_store(ip)
-                      z = z_store(ip)
+    !$omp parallel do default(none) &
+    !$omp             schedule(dynamic) &
+    !$omp             shared(domain, naba_atoms_of_blocks, npoint, offset_position, pao_fns, atomf, &
+    !$omp                    x_store, y_store, z_store, ip_store, pao, gridfunctions, the_species, &
+    !$omp                    n_pts_in_block) &
+    !$omp             private(ia, ipart, iblock, ipoint, l1, acz, m1, count1, x, y, z, val, position)
+    blocks_loop_omp: do iblock = 1, domain%groups_on_node ! primary set of blocks
+       part_if_omp: if(naba_atoms_of_blocks(atomf)%no_of_part(iblock) > 0) then ! if there are naba atoms
+          parts_loop_omp: do ipart=1,naba_atoms_of_blocks(atomf)%no_of_part(iblock)
+             atoms_loop_omp: do ia=1,naba_atoms_of_blocks(atomf)%no_atom_on_part(ipart,iblock)
+                npoint_if_omp : if(npoint(ia, ipart, iblock) > 0) then
+                   points_loop_omp: do ip=1,npoint(ia, ipart, iblock)
+                      ipoint=ip_store(ip, ia, ipart, iblock)
+                      position = offset_position(ia, ipart, iblock) + ipoint
+                      x = x_store(ip, ia, ipart, iblock)
+                      y = y_store(ip, ia, ipart, iblock)
+                      z = z_store(ip, ia, ipart, iblock)
                       ! For this point-atom offset, we accumulate the PAO on the grid
                       count1 = 1
-                      do l1 = 0,pao(the_species)%greatest_angmom
-                         do acz = 1,pao(the_species)%angmom(l1)%n_zeta_in_angmom
-                            do m1=-l1,l1
-                               call evaluate_pao(the_species,l1,acz,m1,x,y,z,val)
-                               !gridfunctions(pao_fns)%griddata(position+(count1-1)*n_pts_in_block) = val
-                               temp_block_storage(ipoint + (count1-1)*n_pts_in_block) = val
+                      l: do l1 = 0,pao(the_species(ia, ipart, iblock))%greatest_angmom
+                         zeta: do acz = 1,pao(the_species(ia, ipart, iblock))%angmom(l1)%n_zeta_in_angmom
+                            m: do m1=-l1,l1
+                               call evaluate_pao(the_species(ia, ipart, iblock),l1,acz,m1,x,y,z,val)
+                               gridfunctions(pao_fns)%griddata(position+(count1-1)*n_pts_in_block) = val
                                count1 = count1+1
-                            end do ! m1
-                         end do ! acz
-                      end do ! l1
-                   enddo ! ip=1,npoint
-                   !$omp end parallel do
-                   gridfunctions(pao_fns)%griddata(no_of_ib_ia+1:no_of_ib_ia+current_num_blocks) = &
-                        temp_block_storage(1:current_num_blocks)
-                endif! (npoint > 0) then
-                no_of_ib_ia = no_of_ib_ia + npao_species(the_species)*n_pts_in_block
-             enddo ! naba_atoms
-          enddo ! naba_part
-       endif !(naba_atoms_of_blocks(atomf)%no_of_part(iblock) > 0) !naba atoms?
-    enddo ! iblock : primary set of blocks
-    deallocate(temp_block_storage)
+                            end do m
+                         end do zeta
+                      end do l
+                   enddo points_loop_omp
+                endif npoint_if_omp
+             enddo atoms_loop_omp
+          enddo parts_loop_omp
+       endif part_if_omp
+    enddo blocks_loop_omp
+    !$omp end parallel do
     call my_barrier()
     call start_timer(tmr_std_allocation)
     deallocate(ip_store,x_store,y_store,z_store,r_store)
@@ -244,21 +270,21 @@ contains
 
 !!****f* PAO_grid_transform_module/single_PAO_to_grad *
 !!
-!!  NAME 
+!!  NAME
 !!   single_PAO_to_grad
 !!  USAGE
-!! 
+!!
 !!  PURPOSE
 !!   Projects the gradient of PAO functions onto the grid (rather than support functions)
 !!   Used for gradients of energy wrt atomic coordinates
 !!
 !!   This subroutine is based on sub:single_PAO_to_grid in PAO_grid_transform_module.f90.
-!!   TODO: There is a lot of code duplication between single_PAO_to_grid and single_PAO_to_grad  
+!!   TODO: There is a lot of code duplication between single_PAO_to_grid and single_PAO_to_grad
 !!
 !!  INPUTS
-!! 
+!!
 !!  USES
-!! 
+!!
 !!  AUTHOR
 !!   A. Nakata
 !!  CREATION DATE
@@ -287,7 +313,7 @@ contains
     use functions_on_grid, ONLY: gridfunctions, fn_on_grid
     use pao_format
 
-    implicit none 
+    implicit none
     integer,intent(in) :: pao_fns
     integer,intent(in) :: direction
 
@@ -334,7 +360,7 @@ contains
 
     max_num_blocks = maxval(npao_species)*n_pts_in_block
     allocate(temp_block_storage(max_num_blocks))
-    
+
     ! loop arround grid points in the domain, and for each
     ! point, get the d_PAO/d_R values
 
@@ -436,15 +462,15 @@ contains
 !!   finds integration grids in a given block
 !!   whose distances from the atom (xatom, yatom, zatom)
 !!   are within a cutoff 'rcut'.
-!! 
+!!
 !!  INPUTS
 !! (xblock, yblock, zblock): the position of the l.h.s.
 !!                             of the block
 !! (xatom, yatom, zatom)   : the position of the atom
-!!             rcut          : cutoff 
+!!             rcut          : cutoff
 !!
 !!  OUTPUTS
-!!    npoint  : # of integration grids whose distances 
+!!    npoint  : # of integration grids whose distances
 !!              from the atom are within the cutoff rcut.
 !!   for the following,  0 < ii < n_pts_in_block.
 !!    ipoint(ii)  : index of found points ii,
@@ -464,7 +490,7 @@ contains
 !!
   subroutine check_block &
        (xblock,yblock,zblock,xatom,yatom,zatom,rcut, &
-       npoint, ip_store, r_store, x_store, y_store, z_store,blocksize) 
+       npoint, ip_store, r_store, x_store, y_store, z_store,blocksize)
 
     use numbers
     use global_module, ONLY: rcellx,rcelly,rcellz
@@ -474,7 +500,7 @@ contains
 
 
     implicit none
-    !Passed 
+    !Passed
     integer :: blocksize
     real(double), intent(in):: xblock, yblock, zblock
     real(double), intent(in):: xatom, yatom, zatom, rcut
@@ -492,9 +518,13 @@ contains
 
 
     rcut2 = rcut* rcut
-    dcellx_block=rcellx/blocks%ngcellx; dcellx_grid=dcellx_block/nx_in_block
-    dcelly_block=rcelly/blocks%ngcelly; dcelly_grid=dcelly_block/ny_in_block
-    dcellz_block=rcellz/blocks%ngcellz; dcellz_grid=dcellz_block/nz_in_block
+    dcellx_block=rcellx/blocks%ngcellx
+    dcelly_block=rcelly/blocks%ngcelly
+    dcellz_block=rcellz/blocks%ngcellz
+
+    dcellx_grid=dcellx_block/nx_in_block
+    dcelly_grid=dcelly_block/ny_in_block
+    dcellz_grid=dcellz_block/nz_in_block
 
     ipoint=0
     npoint=0


### PR DESCRIPTION
The threading implementation in PAO_grid_transform_module currently in `tk-thread-calc-matrix` has a lot of OpenMP overheads, as the vtune analysis below shows. This PR is an attempt to thread the loop over blocks as we originally envisioned, by moving the calculation of offsets to `griddata` into a separate loop. It significantly improves the performance of the threaded region starting around 10s:

![image](https://github.com/OrderN/CONQUEST-release/assets/12845296/99dc7b34-3036-42e0-99f2-e5af5c11b81c)

to

![image](https://github.com/OrderN/CONQUEST-release/assets/12845296/b39fce50-aa90-43cf-b424-0954efa3ff70)


I'd recommend using this as a starting point for implementing #244 