### PR TITLE
Combine single_PAO_to_grid and single_PAO_to_grad

### DIFF
--- a/src/PAO_grid_transform_module.f90
+++ b/src/PAO_grid_transform_module.f90
@@ -114,13 +114,11 @@ contains
     use primary_module, ONLY: domain
     use cover_module, ONLY: DCS_parts
     use set_blipgrid_module, ONLY : naba_atoms_of_blocks
-    !use angular_coeff_routines, ONLY : evaluate_pao, pao_elem_derivative_2
     use functions_on_grid, ONLY: gridfunctions, fn_on_grid
     use pao_format
 
     implicit none
     integer, intent(in) :: pao_fns
-    !procedure(evaluate_interface), intent(in) :: evaluate
     integer, intent(in) :: direction
 
     !local
@@ -143,7 +141,7 @@ contains
 
     interface
        ! Interface to return a value val given arguments
-       ! direction,species,l1,acz,m1,x,y,z. Implemented by
+       ! direction,species,l,acz,m,x,y,z. Implemented by
        ! evaluate_pao() and pao_elem_derivative_2().
        subroutine evaluate(direction,species,l,acz,m,x,y,z,val)
          use datatypes, only: double

--- a/src/PAO_grid_transform_module.f90
+++ b/src/PAO_grid_transform_module.f90
@@ -54,10 +54,10 @@ module PAO_grid_transform_module
 
 contains
 
-!!****f* PAO_grid_transform_module/single_PAO_to_any *
+!!****f* PAO_grid_transform_module/PAO_or_gradPAO_to_grid *
 !!
 !!  NAME
-!!   single_PAO_to_any
+!!   PAO_or_gradPAO_to_grid
 !!  USAGE
 !!
 !!  PURPOSE
@@ -95,10 +95,10 @@ contains
 !!    Removed unused npao1 and atom_species
 !!   2023/08/23 11:20 tkoskela
 !!    Added OMP threading, merged single_PAO_to_grad and single_PAO_to_grid into
-!!    single subroutine single_PAO_to_any (for lack of better name)
+!!    single subroutine PAO_or_gradPAO_to_grid
 !!  SOURCE
 !!
-  subroutine single_PAO_to_any(pao_fns, evaluate, direction)
+  subroutine PAO_or_gradPAO_to_grid(pao_fns, evaluate, direction)
 
     use datatypes, only: double
     use primary_module, ONLY: bundle
@@ -258,7 +258,7 @@ contains
     call stop_timer(tmr_std_allocation)
     call stop_timer(tmr_std_basis)
     return
-  end subroutine single_PAO_to_any
+  end subroutine PAO_or_gradPAO_to_grid
   !!***
 
 ! -----------------------------------------------------------

--- a/src/PAO_grid_transform_module.f90
+++ b/src/PAO_grid_transform_module.f90
@@ -121,7 +121,7 @@ contains
     implicit none
     integer, intent(in) :: pao_fns
     !procedure(evaluate_interface), intent(in) :: evaluate
-    integer, intent(in), optional :: direction
+    integer, intent(in) :: direction
 
     !local
     integer :: iblock,ia,ipart,ip,l1,acz,m1 ! Loop index variables

--- a/src/PAO_grid_transform_module.f90
+++ b/src/PAO_grid_transform_module.f90
@@ -54,10 +54,10 @@ module PAO_grid_transform_module
 
 contains
 
-!!****f* PAO_grid_transform_module/single_PAO_to_grid *
+!!****f* PAO_grid_transform_module/single_PAO_to_any *
 !!
 !!  NAME
-!!   single_PAO_to_grid
+!!   single_PAO_to_any
 !!  USAGE
 !!
 !!  PURPOSE
@@ -93,9 +93,12 @@ contains
 !!    Removed support_spec_format (blips_on_atom and flag_one_to_one) and this_atom,
 !!    which are no longer needed
 !!    Removed unused npao1 and atom_species
+!!   2023/08/23 11:20 tkoskela
+!!    Added OMP threading, merged single_PAO_to_grad and single_PAO_to_grid into
+!!    single subroutine single_PAO_to_any (for lack of better name)
 !!  SOURCE
 !!
-  subroutine single_PAO_to_grid(pao_fns)
+  subroutine single_PAO_to_any(pao_fns, direction)
 
     use datatypes
     use primary_module, ONLY: bundle
@@ -111,12 +114,13 @@ contains
     use primary_module, ONLY: domain
     use cover_module, ONLY: DCS_parts
     use set_blipgrid_module, ONLY : naba_atoms_of_blocks
-    use angular_coeff_routines, ONLY : evaluate_pao
+    use angular_coeff_routines, ONLY : evaluate_pao, pao_elem_derivative_2
     use functions_on_grid, ONLY: gridfunctions, fn_on_grid
     use pao_format
 
     implicit none
-    integer,intent(in) :: pao_fns
+    integer, intent(in) :: pao_fns
+    integer, intent(in), optional :: direction
 
     !local
     integer :: iblock,ia,ipart,ip,l1,acz,m1 ! Loop index variables
@@ -192,7 +196,7 @@ contains
     !$omp             schedule(dynamic) &
     !$omp             shared(domain, naba_atoms_of_blocks, offset_position, pao_fns, atomf, &
     !$omp                    dcellx_block, dcelly_block, dcellz_block, dcs_parts, &
-    !$omp                    rcut, n_pts_in_block, pao, gridfunctions) &
+    !$omp                    rcut, n_pts_in_block, pao, gridfunctions, direction) &
     !$omp             private(ia, ipart, iblock, l1, acz, m1, count1, x, y, z, val, position, &
     !$omp                     npoint, r_store, ip_store, x_store, y_store, z_store, my_species, &
     !$omp                     xblock, yblock, zblock, iatom, xatom, yatom, zatom, naba_part_label, ind_part, icover)
@@ -229,7 +233,11 @@ contains
                       l_loop: do l1 = 0,pao(my_species)%greatest_angmom
                          z_loop: do acz = 1,pao(my_species)%angmom(l1)%n_zeta_in_angmom
                             m_loop: do m1=-l1,l1
-                               call evaluate_pao(my_species,l1,acz,m1,x,y,z,val)
+                               if(present(direction)) then
+                                  call pao_elem_derivative_2(direction,my_species,l1,acz,m1,x,y,z,val)
+                               else
+                                  call evaluate_pao(my_species,l1,acz,m1,x,y,z,val)
+                               end if
                                gridfunctions(pao_fns)%griddata(position) = val
                                position = position + n_pts_in_block
                             end do m_loop
@@ -244,190 +252,11 @@ contains
     !$omp end parallel do
     call my_barrier()
     call start_timer(tmr_std_allocation)
-    ! Could just let these go out of scope at the end?
     deallocate(ip_store,x_store,y_store,z_store,r_store,offset_position)
     call stop_timer(tmr_std_allocation)
     call stop_timer(tmr_std_basis)
     return
-  end subroutine Single_PAO_to_grid
-!!***
-
-!!****f* PAO_grid_transform_module/single_PAO_to_grad *
-!!
-!!  NAME
-!!   single_PAO_to_grad
-!!  USAGE
-!!
-!!  PURPOSE
-!!   Projects the gradient of PAO functions onto the grid (rather than support functions)
-!!   Used for gradients of energy wrt atomic coordinates
-!!
-!!   This subroutine is based on sub:single_PAO_to_grid in PAO_grid_transform_module.f90.
-!!   TODO: There is a lot of code duplication between single_PAO_to_grid and single_PAO_to_grad
-!!
-!!  INPUTS
-!!
-!!  USES
-!!
-!!  AUTHOR
-!!   A. Nakata
-!!  CREATION DATE
-!!   2016/11/10
-!!  MODIFICATION HISTORY
-!!
-!!  SOURCE
-!!
-  subroutine single_PAO_to_grad(direction, pao_fns)
-
-    use datatypes
-    use primary_module, ONLY: bundle
-    use GenComms, ONLY: my_barrier, cq_abort, mtime
-    use dimens, ONLY: r_h
-    use GenComms, ONLY: inode, ionode
-    use numbers
-    use global_module, ONLY: rcellx,rcelly,rcellz,id_glob,ni_in_cell, iprint_basis, species_glob, atomf
-    use species_module, ONLY: species, npao_species
-    !  At present, these arrays are dummy arguments.
-    use block_module, ONLY : nx_in_block,ny_in_block,nz_in_block, n_pts_in_block
-    use group_module, ONLY : blocks, parts
-    use primary_module, ONLY: domain
-    use cover_module, ONLY: DCS_parts
-    use set_blipgrid_module, ONLY : naba_atoms_of_blocks
-    use angular_coeff_routines, ONLY : pao_elem_derivative_2
-    use functions_on_grid, ONLY: gridfunctions, fn_on_grid
-    use pao_format
-
-    implicit none
-    integer,intent(in) :: pao_fns
-    integer,intent(in) :: direction
-
-    !local
-    real(double):: dcellx_block,dcelly_block,dcellz_block
-    integer :: ipart,naba_part_label,ind_part,ia,ii,icover,ig_atom
-    real(double):: xatom,yatom,zatom
-    real(double):: xblock,yblock,zblock
-    integer :: the_species
-    integer :: j,iblock,the_l,ipoint, igrid
-    real(double) :: r_from_i
-    real(double) :: rr,a,b,c,d,x,y,z,nl_potential
-    integer :: no_of_ib_ia, offset_position
-    integer :: position,iatom
-    integer :: stat, nl, npoint, ip
-    integer :: i,m, m1min, m1max,acz,m1,l1,count1
-    integer     , allocatable :: ip_store(:)
-    real(double), allocatable :: x_store(:)
-    real(double), allocatable :: y_store(:)
-    real(double), allocatable :: z_store(:)
-    real(double), allocatable :: r_store(:)
-    real(double) :: rcut
-    real(double) :: val
-    integer :: max_num_blocks, current_num_blocks
-    real(double), dimension(:), allocatable :: temp_block_storage
-
-    call start_timer(tmr_std_basis)
-    call start_timer(tmr_std_allocation)
-    allocate(ip_store(n_pts_in_block),x_store(n_pts_in_block),y_store(n_pts_in_block),z_store(n_pts_in_block), &
-         r_store(n_pts_in_block))
-    call stop_timer(tmr_std_allocation)
-    ! --  Start of subroutine  ---
-
-    dcellx_block=rcellx/blocks%ngcellx
-    dcelly_block=rcelly/blocks%ngcelly
-    dcellz_block=rcellz/blocks%ngcellz
-
-    call my_barrier()
-
-    no_of_ib_ia = 0
-    gridfunctions(pao_fns)%griddata = zero
-
-    max_num_blocks = maxval(npao_species)*n_pts_in_block
-    allocate(temp_block_storage(max_num_blocks))
-
-    ! loop arround grid points in the domain, and for each
-    ! point, get the d_PAO/d_R values
-
-    do iblock = 1, domain%groups_on_node ! primary set of blocks
-       xblock=(domain%idisp_primx(iblock)+domain%nx_origin-1)*dcellx_block
-       yblock=(domain%idisp_primy(iblock)+domain%ny_origin-1)*dcelly_block
-       zblock=(domain%idisp_primz(iblock)+domain%nz_origin-1)*dcellz_block
-       if(naba_atoms_of_blocks(atomf)%no_of_part(iblock) > 0) then ! if there are naba atoms
-          iatom=0
-          do ipart=1,naba_atoms_of_blocks(atomf)%no_of_part(iblock)
-             naba_part_label=naba_atoms_of_blocks(atomf)%list_part(ipart,iblock)
-             ind_part=DCS_parts%lab_cell(naba_part_label)
-             do ia=1,naba_atoms_of_blocks(atomf)%no_atom_on_part(ipart,iblock)
-                iatom=iatom+1
-                ii = naba_atoms_of_blocks(atomf)%list_atom(iatom,iblock)
-                icover= DCS_parts%icover_ibeg(naba_part_label)+ii-1
-                ig_atom= id_glob(parts%icell_beg(ind_part)+ii-1)
-
-                xatom=DCS_parts%xcover(icover)
-                yatom=DCS_parts%ycover(icover)
-                zatom=DCS_parts%zcover(icover)
-                the_species=species_glob(ig_atom)
-
-                !calculates distances between the atom and integration grid points
-                !in the block and stores which integration grids are neighbours.
-                rcut = r_h + RD_ERR
-                call check_block (xblock,yblock,zblock,xatom,yatom,zatom, rcut, &  ! in
-                     npoint,ip_store,r_store,x_store,y_store,z_store,n_pts_in_block) !out
-
-                if(npoint > 0) then
-                   ! Temporary storage
-                   current_num_blocks = npao_species(the_species)*n_pts_in_block
-                   temp_block_storage = zero
-                   offset_position = no_of_ib_ia
-                   !$omp parallel do default(none) &
-                   !$omp             schedule(dynamic) &
-                   !$omp             reduction(+: temp_block_storage) &
-                   !$omp             shared(n_pts_in_block, direction, pao, the_species, offset_position, &
-                   !$omp                    npoint, no_of_ib_ia, ip_store, r_store, x_store, y_store, z_store) &
-                   !$omp             private(r_from_i, ip, position, ipoint, &
-                   !$omp                     x, y, z, l1, acz, m1, count1, val)
-                   do ip=1,npoint
-                      ipoint=ip_store(ip)
-                      position= offset_position + ipoint
-
-                      r_from_i = r_store(ip)
-                      x = x_store(ip)
-                      y = y_store(ip)
-                      z = z_store(ip)
-                      ! For this point-atom offset, we accumulate the PAO on the grid
-                      count1 = 1
-
-                      do l1 = 0,pao(the_species)%greatest_angmom
-                         do acz = 1,pao(the_species)%angmom(l1)%n_zeta_in_angmom
-                            do m1=-l1,l1
-                               call pao_elem_derivative_2(direction,the_species,l1,acz,m1,x,y,z,val)
-                               ! Each loop iteration accesses consequtive elements of gridfunctions%griddata
-                               ! so this should be safe as a shared variable. Incrementing the index
-                               ! inside the loop might not be great for vectorization, but with the function
-                               ! call here, it probably won't vectorize anyways.
-                               ! This loop nest really should be inside pao_elem_derivative_2, see issue #198
-                               !gridfunctions(pao_fns)%griddata(position+(count1-1)*n_pts_in_block) = val
-                               temp_block_storage(ipoint + (count1-1)*n_pts_in_block) = val
-                               count1 = count1+1
-                            end do ! m1
-                         end do ! acz
-                      end do ! l1
-                   enddo ! ip=1,npoint
-                   !$omp end parallel do
-                   gridfunctions(pao_fns)%griddata(no_of_ib_ia+1:no_of_ib_ia+current_num_blocks) = &
-                        temp_block_storage(1:current_num_blocks)
-                endif! (npoint > 0) then
-                no_of_ib_ia = no_of_ib_ia + npao_species(the_species)*n_pts_in_block
-             enddo ! naba_atoms
-          enddo ! naba_part
-       endif !(naba_atoms_of_blocks(atomf)%no_of_part(iblock) > 0) !naba atoms?
-    enddo ! iblock : primary set of blocks
-    deallocate(temp_block_storage)
-    call my_barrier()
-    call start_timer(tmr_std_allocation)
-    deallocate(ip_store,x_store,y_store,z_store,r_store)
-    call stop_timer(tmr_std_allocation)
-    call stop_timer(tmr_std_basis)
-    return
-  end subroutine Single_PAO_to_grad
+  end subroutine single_PAO_to_any
 !!***
 
 ! -----------------------------------------------------------

--- a/src/S_matrix_module.f90
+++ b/src/S_matrix_module.f90
@@ -253,7 +253,7 @@ contains
     use mult_module,                 only: matSatomf
     use build_PAO_matrices,          only: assemble_2
     use io_module,                   only: dump_matrix
-    use PAO_grid_transform_module,   only: single_PAO_to_grid
+    use PAO_grid_transform_module,   only: single_PAO_to_any
     use functions_on_grid,           only: atomfns
 
     implicit none
@@ -271,7 +271,7 @@ contains
     ! calculate PAO values on grids
     if (inode == ionode .and. iprint_ops + min_layer > 3) &
          write (io_lun, fmt='(10x,a,i5)') 'single PAO to grid ', atomfns
-    call single_PAO_to_grid(atomfns)
+    call single_PAO_to_any(atomfns)
 
     return
   end subroutine get_S_matrix_PAO

--- a/src/S_matrix_module.f90
+++ b/src/S_matrix_module.f90
@@ -255,6 +255,7 @@ contains
     use io_module,                   only: dump_matrix
     use PAO_grid_transform_module,   only: single_PAO_to_any
     use functions_on_grid,           only: atomfns
+    use angular_coeff_routines,      only: evaluate_pao
 
     implicit none
 
@@ -271,7 +272,7 @@ contains
     ! calculate PAO values on grids
     if (inode == ionode .and. iprint_ops + min_layer > 3) &
          write (io_lun, fmt='(10x,a,i5)') 'single PAO to grid ', atomfns
-    call single_PAO_to_any(atomfns)
+    call single_PAO_to_any(atomfns, evaluate_pao, 0)
 
     return
   end subroutine get_S_matrix_PAO

--- a/src/S_matrix_module.f90
+++ b/src/S_matrix_module.f90
@@ -253,7 +253,7 @@ contains
     use mult_module,                 only: matSatomf
     use build_PAO_matrices,          only: assemble_2
     use io_module,                   only: dump_matrix
-    use PAO_grid_transform_module,   only: single_PAO_to_any
+    use PAO_grid_transform_module,   only: PAO_or_gradPAO_to_grid
     use functions_on_grid,           only: atomfns
     use angular_coeff_routines,      only: evaluate_pao
 
@@ -272,7 +272,7 @@ contains
     ! calculate PAO values on grids
     if (inode == ionode .and. iprint_ops + min_layer > 3) &
          write (io_lun, fmt='(10x,a,i5)') 'single PAO to grid ', atomfns
-    call single_PAO_to_any(atomfns, evaluate_pao, 0)
+    call PAO_or_gradPAO_to_grid(atomfns, evaluate_pao, 0)
 
     return
   end subroutine get_S_matrix_PAO

--- a/src/exx_evalpao.f90
+++ b/src/exx_evalpao.f90
@@ -173,7 +173,7 @@ contains
                       pao_val = zero
                       y_val   = zero             
                       rec_ylm: if (.not.exx_cartesian) then                      
-                         call evaluate_pao(spec,l1,acz,m1,x,y,z,pao_val)
+                         call evaluate_pao(0,spec,l1,acz,m1,x,y,z,pao_val)
                       else
                          npts  = pao(spec)%angmom(l1)%zeta(acz)%length
                          del_r = (pao(spec)%angmom(l1)%zeta(acz)%cutoff/&

--- a/src/force_module.f90
+++ b/src/force_module.f90
@@ -964,7 +964,7 @@ contains
                                            inode, ionode
     !use DiagModule,                  only: diagon
 !    use blip_gradient,               only: get_support_gradient
-    use PAO_grid_transform_module,   only: single_PAO_to_any
+    use PAO_grid_transform_module,   only: PAO_or_gradPAO_to_grid
     use build_PAO_matrices,          only: assemble_deriv_2
     use cover_module,                only: BCS_parts
     use functions_on_grid,           only: atomfns,                  &
@@ -1311,7 +1311,7 @@ contains
           if (flag_basis_set == blips) then
              call blip_to_grad_new(inode-1, dir1, tmp_fn)
           else if (flag_basis_set == PAOs) then
-             call single_PAO_to_any(tmp_fn, pao_elem_derivative_2, dir1)
+             call PAO_or_gradPAO_to_grid(tmp_fn, pao_elem_derivative_2, dir1)
           else
              call cq_abort("pulay_force: basis set undefined ", flag_basis_set)
           end if

--- a/src/force_module.f90
+++ b/src/force_module.f90
@@ -988,6 +988,7 @@ contains
     use GenBlas,                     only: axpy, scal
     use calc_matrix_elements_module, only: act_on_vectors_new
     use io_module,                   only: return_prefix
+    use angular_coeff_routines,      ONLY: pao_elem_derivative_2
 
     implicit none
 
@@ -1310,7 +1311,7 @@ contains
           if (flag_basis_set == blips) then
              call blip_to_grad_new(inode-1, dir1, tmp_fn)
           else if (flag_basis_set == PAOs) then
-             call single_PAO_to_any(tmp_fn, dir1)
+             call single_PAO_to_any(tmp_fn, pao_elem_derivative_2, dir1)
           else
              call cq_abort("pulay_force: basis set undefined ", flag_basis_set)
           end if

--- a/src/force_module.f90
+++ b/src/force_module.f90
@@ -964,7 +964,7 @@ contains
                                            inode, ionode
     !use DiagModule,                  only: diagon
 !    use blip_gradient,               only: get_support_gradient
-    use PAO_grid_transform_module,   only: single_PAO_to_grad
+    use PAO_grid_transform_module,   only: single_PAO_to_any
     use build_PAO_matrices,          only: assemble_deriv_2
     use cover_module,                only: BCS_parts
     use functions_on_grid,           only: atomfns,                  &
@@ -1310,7 +1310,7 @@ contains
           if (flag_basis_set == blips) then
              call blip_to_grad_new(inode-1, dir1, tmp_fn)
           else if (flag_basis_set == PAOs) then
-             call single_PAO_to_grad(dir1, tmp_fn)
+             call single_PAO_to_any(tmp_fn, dir1)
           else
              call cq_abort("pulay_force: basis set undefined ", flag_basis_set)
           end if

--- a/src/multisiteSF_module.f90
+++ b/src/multisiteSF_module.f90
@@ -130,7 +130,7 @@ contains
     use dimens,                    only: n_my_grid_points
     use maxima_module,             only: maxngrid
     use functions_on_grid,         only: atomfns, H_on_atomfns
-    use PAO_grid_transform_module, only: single_PAO_to_grid
+    use PAO_grid_transform_module, only: single_PAO_to_any
     use S_matrix_module,           only: get_S_matrix
     use H_matrix_module,           only: get_H_matrix
     use store_matrix,              only: dump_pos_and_matrices
@@ -164,7 +164,7 @@ contains
     if (flag_LFD) then
        ! Prepare Spao and Hpao
        ! 1. Calculate PAO values on grids
-       if (LFD_build_Spao) call single_PAO_to_grid(atomfns)
+       if (LFD_build_Spao) call single_PAO_to_any(atomfns)
        ! 2. Construct matSpao
        if (LFD_build_Spao) call get_S_matrix(inode, ionode, transform_AtomF_to_SF=.false.)
        ! 3. Construct matHpao

--- a/src/multisiteSF_module.f90
+++ b/src/multisiteSF_module.f90
@@ -130,7 +130,7 @@ contains
     use dimens,                    only: n_my_grid_points
     use maxima_module,             only: maxngrid
     use functions_on_grid,         only: atomfns, H_on_atomfns
-    use PAO_grid_transform_module, only: single_PAO_to_any
+    use PAO_grid_transform_module, only: PAO_or_gradPAO_to_grid
     use S_matrix_module,           only: get_S_matrix
     use H_matrix_module,           only: get_H_matrix
     use store_matrix,              only: dump_pos_and_matrices
@@ -165,7 +165,7 @@ contains
     if (flag_LFD) then
        ! Prepare Spao and Hpao
        ! 1. Calculate PAO values on grids
-       if (LFD_build_Spao) call single_PAO_to_any(atomfns, evaluate_pao, 0)
+       if (LFD_build_Spao) call PAO_or_gradPAO_to_grid(atomfns, evaluate_pao, 0)
        ! 2. Construct matSpao
        if (LFD_build_Spao) call get_S_matrix(inode, ionode, transform_AtomF_to_SF=.false.)
        ! 3. Construct matHpao

--- a/src/multisiteSF_module.f90
+++ b/src/multisiteSF_module.f90
@@ -136,6 +136,7 @@ contains
     use store_matrix,              only: dump_pos_and_matrices
     use GenComms,                  only: mtime
     use io_module,                 only: return_prefix
+    use angular_coeff_routines,    only: evaluate_pao
 
     implicit none
 
@@ -164,7 +165,7 @@ contains
     if (flag_LFD) then
        ! Prepare Spao and Hpao
        ! 1. Calculate PAO values on grids
-       if (LFD_build_Spao) call single_PAO_to_any(atomfns)
+       if (LFD_build_Spao) call single_PAO_to_any(atomfns, evaluate_pao, 0)
        ! 2. Construct matSpao
        if (LFD_build_Spao) call get_S_matrix(inode, ionode, transform_AtomF_to_SF=.false.)
        ! 3. Construct matHpao

--- a/src/ol_ang_coeff_subs.f90
+++ b/src/ol_ang_coeff_subs.f90
@@ -833,7 +833,7 @@ contains
 !!  SOURCE
 !!
 
-  subroutine evaluate_pao(sp,l,nz,m,x,y,z,pao_val)
+  subroutine evaluate_pao(i_vector,sp,l,nz,m,x,y,z,pao_val)
 
     use datatypes
     use numbers
@@ -841,6 +841,7 @@ contains
 
     implicit none
 
+    integer, intent(in) :: i_vector ! dummy argument, included to satisfy interface in PAO_grid_transform_module
     integer, intent(in) :: sp,l,nz,m
     real(double), intent(in) :: x,y,z
     real(double), intent(out) :: pao_val
@@ -968,7 +969,7 @@ contains
     
     !RC 09/11/03 using (now debugged) routine pp_elem_derivative (see 
     ! above) as template for this sbrt pao_elem_derivative
-    real(double), intent(inout) :: x_i,y_i,z_i
+    real(double), intent(in) :: x_i,y_i,z_i
     real(double), intent(out) :: drvtv_val
     integer, intent(in) :: i_vector, l, m, spec, nzeta
     integer :: n1,n2

--- a/src/system.make
+++ b/src/system.make
@@ -1,49 +1,29 @@
-#
-
 # Set compilers
-FC=mpif90
+FC=mpifort
 F77=mpif77
-
+# OMP flag for compiler and linker
+OMPFLAG= -fopenmp
 # Linking flags
-LINKFLAGS= -L/usr/local/lib
+LINKFLAGS= -L/usr/lib -L/usr/lib/x86_64-linux-gnu $(OMPFLAG)
 ARFLAGS=
-
-# Compilation flags
-# NB for gcc10 you need to add -fallow-argument-mismatch
-COMPFLAGS= -O3 $(XC_COMPFLAGS)
-COMPFLAGS_F77= $(COMPFLAGS)
-
 # Set BLAS and LAPACK libraries
-# MacOS X
-# BLAS= -lvecLibFort
-# Intel MKL use the Intel tool
-# Generic
-# BLAS= -llapack -lblas
-
-# Full library call; remove scalapack if using dummy diag module
-LIBS= $(FFT_LIB) $(XC_LIB) -lscalapack $(BLAS)
-
+BLAS= -llapack -lblas
 # LibXC compatibility (LibXC below) or Conquest XC library
-
 # Conquest XC library
-#XC_LIBRARY = CQ
-#XC_LIB =
-#XC_COMPFLAGS =
-
-# LibXC compatibility
-# Choose LibXC version: v4 (deprecated) or v5/6 (v5 and v6 have the same interface)
-# XC_LIBRARY = LibXC_v4
 XC_LIBRARY = LibXC_v5
 XC_LIB = -lxcf90 -lxc
-XC_COMPFLAGS = -I/usr/local/include
-
+XC_COMPFLAGS = -I/usr/include
 # Set FFT library
 FFT_LIB=-lfftw3
 FFT_OBJ=fft_fftw3.o
-
 # Matrix multiplication kernel type
 MULT_KERN = default
 # Use dummy DiagModule or not
 DIAG_DUMMY =
-
-
+# Full library call; remove scalapack if using dummy diag module
+LIBS= $(XC_LIB) -lscalapack-openmpi $(BLAS) $(FFT_LIB)
+# Compilation flags
+# NB for gcc10 you need to add -fallow-argument-mismatch
+FPPFLAGS= -DDEBUG
+COMPFLAGS= -cpp -g -O3 $(OMPFLAG) $(XC_COMPFLAGS) -fallow-argument-mismatch $(FPPFLAGS)
+COMPFLAGS_F77= $(COMPFLAGS)

--- a/src/test_force_module.f90
+++ b/src/test_force_module.f90
@@ -1642,6 +1642,7 @@ contains
     use density_module,             only: density
     use maxima_module,              only: maxngrid
     use memory_module,              only: reg_alloc_mem, reg_dealloc_mem, type_dbl
+    use angular_coeff_routines,     only: evaluate_pao
 
     implicit none
 
@@ -1710,7 +1711,7 @@ contains
        call blip_to_support_new(inode-1, atomfns)    
     else if (flag_basis_set == PAOs) then
        ! Regenerate PAO with a call to single_PAO_to_any
-       call single_PAO_to_any(atomfns)
+       call single_PAO_to_any(atomfns, evaluate_pao, 0)
     end if
     ! Note that we've held K fixed but allow potential to vary ? Yes:
     ! this way we get h_on_atomfns in workspace_support

--- a/src/test_force_module.f90
+++ b/src/test_force_module.f90
@@ -1605,7 +1605,7 @@ contains
   !!   2016/08/08 15:30 nakata
   !!    Renamed supportfns -> atomfns
   !!   2016/12/29 19:30 nakata
-  !!    Changed PAO_to_grid to single_PAO_to_grid
+  !!    Changed PAO_to_grid to single_PAO_to_any
   !!   2017/10/27 09:55 dave
   !!    Bug fix: p_force not being zeroed before second call made
   !!    analytic force wrong
@@ -1637,7 +1637,7 @@ contains
     use GenComms,                   only: myid, inode, ionode, cq_abort
     use H_matrix_module,            only: get_H_matrix
     use blip_grid_transform_module, only: blip_to_support_new
-    use PAO_grid_transform_module,  only: single_PAO_to_grid
+    use PAO_grid_transform_module,  only: single_PAO_to_any
     use functions_on_grid,          only: atomfns
     use density_module,             only: density
     use maxima_module,              only: maxngrid
@@ -1709,8 +1709,8 @@ contains
        ! Reproject blips
        call blip_to_support_new(inode-1, atomfns)    
     else if (flag_basis_set == PAOs) then
-       ! Regenerate PAO with a call to single_PAO_to_grid
-       call single_PAO_to_grid(atomfns)
+       ! Regenerate PAO with a call to single_PAO_to_any
+       call single_PAO_to_any(atomfns)
     end if
     ! Note that we've held K fixed but allow potential to vary ? Yes:
     ! this way we get h_on_atomfns in workspace_support

--- a/src/test_force_module.f90
+++ b/src/test_force_module.f90
@@ -1605,7 +1605,7 @@ contains
   !!   2016/08/08 15:30 nakata
   !!    Renamed supportfns -> atomfns
   !!   2016/12/29 19:30 nakata
-  !!    Changed PAO_to_grid to single_PAO_to_any
+  !!    Changed PAO_to_grid to single_PAO_to_grid
   !!   2017/10/27 09:55 dave
   !!    Bug fix: p_force not being zeroed before second call made
   !!    analytic force wrong

--- a/src/test_force_module.f90
+++ b/src/test_force_module.f90
@@ -1637,7 +1637,7 @@ contains
     use GenComms,                   only: myid, inode, ionode, cq_abort
     use H_matrix_module,            only: get_H_matrix
     use blip_grid_transform_module, only: blip_to_support_new
-    use PAO_grid_transform_module,  only: single_PAO_to_any
+    use PAO_grid_transform_module,  only: PAO_or_gradPAO_to_grid
     use functions_on_grid,          only: atomfns
     use density_module,             only: density
     use maxima_module,              only: maxngrid
@@ -1710,8 +1710,8 @@ contains
        ! Reproject blips
        call blip_to_support_new(inode-1, atomfns)    
     else if (flag_basis_set == PAOs) then
-       ! Regenerate PAO with a call to single_PAO_to_any
-       call single_PAO_to_any(atomfns, evaluate_pao, 0)
+       ! Regenerate PAO with a call to PAO_or_gradPAO_to_grid
+       call PAO_or_gradPAO_to_grid(atomfns, evaluate_pao, 0)
     end if
     ! Note that we've held K fixed but allow potential to vary ? Yes:
     ! this way we get h_on_atomfns in workspace_support


### PR DESCRIPTION
Closes #244 

I've merged the two identical subroutines into `PAO_or_gradPAO_to_grid`. The subroutine called in the inner loop is passed in as a procedure argument through an interface. As a side effect I had to always pass `direction` into both subroutines to make them conform to the same interface, in `evaluate_pao` it's just a dummy argument that does nothing. I've updated all calls to `PAO_or_gradPAO_to_grid`, `evaluate_pao` and `pao_elem_derivative_2` and added a bit of explanation in comments.

Very open to a more descriptive names for the subroutine and the interface

Gets rid of OpenMP overheads in `single_PAO_to_grad` we were seeing earlier

## Previously:
![image](https://github.com/OrderN/CONQUEST-release/assets/12845296/d87c6d14-76c5-410d-b540-ac88010b2a1c)


## This PR:
![image](https://github.com/OrderN/CONQUEST-release/assets/12845296/12a7562c-3a38-4cdd-b6d5-afec77fe3bf2)
