### PR TITLE
Fix issues with eigenvalue output format

### DIFF
--- a/src/io_module.f90
+++ b/src/io_module.f90
@@ -1641,7 +1641,7 @@ second:   do
     close(io)
     !    
 4   format(10x,'Sum of eigenvalues: ',f18.11,' ',a2)
-7   format(10x,'Eigenvalues and occupancies for k-point ',i3,' : ',3f12.5)
+7   format(10x,'Eigenvalues and occupancies for k-point ',i6,' : ',3f12.5)
 8   format(10x,f15.7,x,f8.5,2x)
 9   format(10x,f15.7,x,f8.5,2x,f15.7,x,f8.5,2x)
 10  format(10x,f15.7,x,f8.5,2x,f15.7,x,f8.5,2x,f15.7,x,f8.5)

--- a/src/io_module.f90
+++ b/src/io_module.f90
@@ -1491,7 +1491,7 @@ second:   do
     
     call io_assign (lun)
     open (unit = lun, file = 'eigenvalues.dat')
-    write(lun,fmt='("#  ",i7," eigenvalues ",i4," kpoints")') n_evals, nkp
+    write(lun,fmt='("#  ",i7," eigenvalues ",i6," kpoints")') n_evals, nkp
     if(nspin==1) then
        write(lun,fmt='("# Ef: ",f18.10)') Ef(1)
     else
@@ -1500,7 +1500,7 @@ second:   do
     write(lun,fmt='("# Format: nk kx ky kz weight, followed by eigenvalues")')
     do sp = 1,nspin
        do kp = 1,nkp
-          write(lun,fmt='(i4,4f12.5)') kp,kk(1,kp),kk(2,kp),kk(3,kp),wtk(kp)
+          write(lun,fmt='(i6,3f12.5,f17.10)') kp,kk(1,kp),kk(2,kp),kk(3,kp),wtk(kp)
           do ev = 1,n_evals
              write(lun,fmt='(i6,f18.10)') ev,eval(ev,kp,sp)
           end do

--- a/tools/PostProcessing/read_module.f90
+++ b/tools/PostProcessing/read_module.f90
@@ -272,6 +272,7 @@ contains
           E_wf_max =  BIG
        end if
        flag_wf_range = .true.
+       flag_wf_range_Ef = fdf_boolean('IO.WFRangeRelative',.true.)
        flag_procwf_range_Ef = fdf_boolean('Process.WFRangeRelative',.false.)
        flag_l_resolved = fdf_boolean('Process.pDOS_l_resolved',.false.)
        flag_lm_resolved = fdf_boolean('Process.pDOS_lm_resolved',.false.)


### PR DESCRIPTION
Add extra digits to k-point weight and number of k-point formatting in Conquest output.  Also ensure that projected DOS checks for limited energy window output from Conquest (read the appropriate flag)