### PR TITLE
Fix all benchmarks to output to stdout

### DIFF
--- a/benchmarks/matrix_multiply/Conquest_input
+++ b/benchmarks/matrix_multiply/Conquest_input
@@ -1,6 +1,7 @@
 AtomMove.TypeOfRun static
 IO.Coordinates coords.dat
 IO.Iprint 0
+IO.WriteOutToFile F
 Grid.GridCutoff  200
 DM.SolutionMethod ordern
 DM.L_range 16.0

--- a/benchmarks/water_64mols/Conquest_input
+++ b/benchmarks/water_64mols/Conquest_input
@@ -2,6 +2,7 @@ IO.Title    Water static test, DZ, GridCutoff=50Ha
 IO.Coordinates    H2O_coord.in
 IO.FractionalAtomicCoords F
 IO.Iprint 1
+IO.WriteOutToFile F
 General.DistanceUnits Angstrom
 IO.WriteOutToFile F
 


### PR DESCRIPTION
Minor fix: I'd like all benchmarks to have the same target for their output to make automation simpler. It's easier to deal with stdout than the `Conquest_out` file.