### PR TITLE
Fix multiply kernel memory leak

### DIFF
--- a/src/matrix_module.f90
+++ b/src/matrix_module.f90
@@ -673,6 +673,8 @@ contains
     if(stat/=0) then
        call cq_abort('alloc_halo: error allocating ndimi')
     endif
+    halo%ndimi = 0
+    halo%ndimj = 0
     call stop_timer(tmr_std_allocation)
     return
   end subroutine allocate_halo

--- a/src/multiply_kernel_default.f90
+++ b/src/multiply_kernel_default.f90
@@ -148,12 +148,12 @@ contains
     real(double)       :: c(lenc)
     integer, optional  :: debug
     ! Remote indices
-    integer(integ) :: ib_nd_acc(mx_part)
-    integer(integ) :: ibaddr(mx_part)
-    integer(integ) :: nbnab(mx_part)
-    integer(integ) :: ibpart(mx_part*mx_absb)
-    integer(integ) :: ibseq(mx_part*mx_absb)
-    integer(integ) :: bndim2(mx_part*mx_absb)
+    integer(integ), intent(in) :: ib_nd_acc(:)
+    integer(integ), intent(in) :: ibaddr(:)
+    integer(integ), intent(in) :: nbnab(:)
+    integer(integ), intent(in) :: ibpart(:)
+    integer(integ), intent(in) :: ibseq(:)
+    integer(integ), intent(in) :: bndim2(:)
     ! Local variables
     integer :: jbnab2ch(mx_absb)  ! Automatic array
     integer :: nbkbeg, k, k_in_part, k_in_halo, j, jpart, jseq
@@ -341,12 +341,12 @@ contains
     real(double)       :: b(lenb)
     real(double)       :: c(lenc)
     ! dimension declarations
-    integer :: ibaddr(mx_part)
-    integer :: ib_nd_acc(mx_part)
-    integer :: nbnab(mx_part)
-    integer :: ibpart(mx_part*mx_absb)
-    integer :: ibseq(mx_part*mx_absb)
-    integer :: bndim2(mx_part*mx_absb)
+    integer(integ), intent(in) :: ib_nd_acc(:)
+    integer(integ), intent(in) :: ibaddr(:)
+    integer(integ), intent(in) :: nbnab(:)
+    integer(integ), intent(in) :: ibpart(:)
+    integer(integ), intent(in) :: ibseq(:)
+    integer(integ), intent(in) :: bndim2(:)
     ! Local variables
     integer :: jbnab2ch(mx_absb)
     integer :: k, k_in_part, k_in_halo, nbkbeg, j, jpart, jseq

--- a/src/multiply_kernel_gemm.f90
+++ b/src/multiply_kernel_gemm.f90
@@ -149,12 +149,12 @@ contains
     real(double) :: c(lenc)
     integer, optional :: debug
     ! Remote indices
-    integer(integ) :: ib_nd_acc(mx_part)
-    integer(integ) :: ibaddr(mx_part)
-    integer(integ) :: nbnab(mx_part)
-    integer(integ) :: ibpart(mx_part*mx_absb)
-    integer(integ) :: ibseq(mx_part*mx_absb)
-    integer(integ) :: bndim2(mx_part*mx_absb)
+    integer(integ), intent(in) :: ib_nd_acc(:)
+    integer(integ), intent(in) :: ibaddr(:)
+    integer(integ), intent(in) :: nbnab(:)
+    integer(integ), intent(in) :: ibpart(:)
+    integer(integ), intent(in) :: ibseq(:)
+    integer(integ), intent(in) :: bndim2(:)
     ! Local variables
     integer :: jbnab2ch(mx_absb)  ! Automatic array
     integer :: nbkbeg, k, k_in_part, k_in_halo, j, jpart, jseq
@@ -398,12 +398,12 @@ contains
     real(double) :: b(lenb)
     real(double) :: c(lenc)
     ! dimension declarations
-    integer :: ibaddr(mx_part)
-    integer :: ib_nd_acc(mx_part)
-    integer :: nbnab(mx_part)
-    integer :: ibpart(mx_part*mx_absb)
-    integer :: ibseq(mx_part*mx_absb)
-    integer :: bndim2(mx_part*mx_absb)
+    integer(integ), intent(in) :: ib_nd_acc(:)
+    integer(integ), intent(in) :: ibaddr(:)
+    integer(integ), intent(in) :: nbnab(:)
+    integer(integ), intent(in) :: ibpart(:)
+    integer(integ), intent(in) :: ibseq(:)
+    integer(integ), intent(in) :: bndim2(:)
     ! Local variables
     integer :: jbnab2ch(mx_absb)
     integer :: k, k_in_part, k_in_halo, nbkbeg, j, jpart, jseq

--- a/src/multiply_kernel_ompDoii.f90
+++ b/src/multiply_kernel_ompDoii.f90
@@ -168,12 +168,12 @@ contains
     real(double)       :: c(lenc)
     integer, optional  :: debug
     ! Remote indices
-    integer(integ) :: ib_nd_acc(mx_part)
-    integer(integ) :: ibaddr(mx_part)
-    integer(integ) :: nbnab(mx_part)
-    integer(integ) :: ibpart(mx_part*mx_absb)
-    integer(integ) :: ibseq(mx_part*mx_absb)
-    integer(integ) :: bndim2(mx_part*mx_absb)
+    integer(integ), intent(in) :: ib_nd_acc(:)
+    integer(integ), intent(in) :: ibaddr(:)
+    integer(integ), intent(in) :: nbnab(:)
+    integer(integ), intent(in) :: ibpart(:)
+    integer(integ), intent(in) :: ibseq(:)
+    integer(integ), intent(in) :: bndim2(:)
     ! Local variables
     integer :: jbnab2ch(mx_absb)  ! Automatic array
     integer :: nbkbeg, k, k_in_part, k_in_halo, j, jpart, jseq
@@ -380,12 +380,12 @@ contains
     real(double)       :: b(lenb)
     real(double)       :: c(lenc)
     ! dimension declarations
-    integer :: ibaddr(mx_part)
-    integer :: ib_nd_acc(mx_part)
-    integer :: nbnab(mx_part)
-    integer :: ibpart(mx_part*mx_absb)
-    integer :: ibseq(mx_part*mx_absb)
-    integer :: bndim2(mx_part*mx_absb)
+    integer(integ), intent(in) :: ib_nd_acc(:)
+    integer(integ), intent(in) :: ibaddr(:)
+    integer(integ), intent(in) :: nbnab(:)
+    integer(integ), intent(in) :: ibpart(:)
+    integer(integ), intent(in) :: ibseq(:)
+    integer(integ), intent(in) :: bndim2(:)
     ! Local variables
     integer :: jbnab2ch(mx_absb)
     integer :: k, k_in_part, k_in_halo, nbkbeg, j, jpart, jseq

--- a/src/multiply_kernel_ompDoik.f90
+++ b/src/multiply_kernel_ompDoik.f90
@@ -168,12 +168,12 @@ contains
     real(double)       :: c(lenc)
     integer, optional  :: debug
     ! Remote indices
-    integer(integ) :: ib_nd_acc(mx_part)
-    integer(integ) :: ibaddr(mx_part)
-    integer(integ) :: nbnab(mx_part)
-    integer(integ) :: ibpart(mx_part*mx_absb)
-    integer(integ) :: ibseq(mx_part*mx_absb)
-    integer(integ) :: bndim2(mx_part*mx_absb)
+    integer(integ), intent(in) :: ib_nd_acc(:)
+    integer(integ), intent(in) :: ibaddr(:)
+    integer(integ), intent(in) :: nbnab(:)
+    integer(integ), intent(in) :: ibpart(:)
+    integer(integ), intent(in) :: ibseq(:)
+    integer(integ), intent(in) :: bndim2(:)
     ! Local variables
     integer :: jbnab2ch(mx_absb)  ! Automatic array
     integer :: nbkbeg, k, k_in_part, k_in_halo, j, jpart, jseq
@@ -380,12 +380,12 @@ contains
     real(double)       :: b(lenb)
     real(double)       :: c(lenc)
     ! dimension declarations
-    integer :: ibaddr(mx_part)
-    integer :: ib_nd_acc(mx_part)
-    integer :: nbnab(mx_part)
-    integer :: ibpart(mx_part*mx_absb)
-    integer :: ibseq(mx_part*mx_absb)
-    integer :: bndim2(mx_part*mx_absb)
+    integer(integ), intent(in) :: ib_nd_acc(:)
+    integer(integ), intent(in) :: ibaddr(:)
+    integer(integ), intent(in) :: nbnab(:)
+    integer(integ), intent(in) :: ibpart(:)
+    integer(integ), intent(in) :: ibseq(:)
+    integer(integ), intent(in) :: bndim2(:)
     ! Local variables
     integer :: jbnab2ch(mx_absb)
     integer :: k, k_in_part, k_in_halo, nbkbeg, j, jpart, jseq

--- a/src/multiply_kernel_ompDoji.f90
+++ b/src/multiply_kernel_ompDoji.f90
@@ -168,12 +168,12 @@ contains
     real(double)       :: c(lenc)
     integer, optional  :: debug
     ! Remote indices
-    integer(integ) :: ib_nd_acc(mx_part)
-    integer(integ) :: ibaddr(mx_part)
-    integer(integ) :: nbnab(mx_part)
-    integer(integ) :: ibpart(mx_part*mx_absb)
-    integer(integ) :: ibseq(mx_part*mx_absb)
-    integer(integ) :: bndim2(mx_part*mx_absb)
+    integer(integ), intent(in) :: ib_nd_acc(:)
+    integer(integ), intent(in) :: ibaddr(:)
+    integer(integ), intent(in) :: nbnab(:)
+    integer(integ), intent(in) :: ibpart(:)
+    integer(integ), intent(in) :: ibseq(:)
+    integer(integ), intent(in) :: bndim2(:)
     ! Local variables
     integer :: jbnab2ch(mx_absb)  ! Automatic array
     integer :: nbkbeg, k, k_in_part, k_in_halo, j, jpart, jseq
@@ -389,12 +389,12 @@ contains
     real(double)       :: b(lenb)
     real(double)       :: c(lenc)
     ! dimension declarations
-    integer :: ibaddr(mx_part)
-    integer :: ib_nd_acc(mx_part)
-    integer :: nbnab(mx_part)
-    integer :: ibpart(mx_part*mx_absb)
-    integer :: ibseq(mx_part*mx_absb)
-    integer :: bndim2(mx_part*mx_absb)
+    integer(integ), intent(in) :: ib_nd_acc(:)
+    integer(integ), intent(in) :: ibaddr(:)
+    integer(integ), intent(in) :: nbnab(:)
+    integer(integ), intent(in) :: ibpart(:)
+    integer(integ), intent(in) :: ibseq(:)
+    integer(integ), intent(in) :: bndim2(:)
     ! Local variables
     integer :: jbnab2ch(mx_absb)
     integer :: k, k_in_part, k_in_halo, nbkbeg, j, jpart, jseq

--- a/src/multiply_kernel_ompDojk.f90
+++ b/src/multiply_kernel_ompDojk.f90
@@ -168,12 +168,12 @@ contains
     real(double)       :: c(lenc)
     integer, optional  :: debug
     ! Remote indices
-    integer(integ) :: ib_nd_acc(mx_part)
-    integer(integ) :: ibaddr(mx_part)
-    integer(integ) :: nbnab(mx_part)
-    integer(integ) :: ibpart(mx_part*mx_absb)
-    integer(integ) :: ibseq(mx_part*mx_absb)
-    integer(integ) :: bndim2(mx_part*mx_absb)
+    integer(integ), intent(in) :: ib_nd_acc(:)
+    integer(integ), intent(in) :: ibaddr(:)
+    integer(integ), intent(in) :: nbnab(:)
+    integer(integ), intent(in) :: ibpart(:)
+    integer(integ), intent(in) :: ibseq(:)
+    integer(integ), intent(in) :: bndim2(:)
     ! Local variables
     integer :: jbnab2ch(mx_absb)  ! Automatic array
     integer :: nbkbeg, k, k_in_part, k_in_halo, j, jpart, jseq
@@ -380,12 +380,12 @@ contains
     real(double)       :: b(lenb)
     real(double)       :: c(lenc)
     ! dimension declarations
-    integer :: ibaddr(mx_part)
-    integer :: ib_nd_acc(mx_part)
-    integer :: nbnab(mx_part)
-    integer :: ibpart(mx_part*mx_absb)
-    integer :: ibseq(mx_part*mx_absb)
-    integer :: bndim2(mx_part*mx_absb)
+    integer(integ), intent(in) :: ib_nd_acc(:)
+    integer(integ), intent(in) :: ibaddr(:)
+    integer(integ), intent(in) :: nbnab(:)
+    integer(integ), intent(in) :: ibpart(:)
+    integer(integ), intent(in) :: ibseq(:)
+    integer(integ), intent(in) :: bndim2(:)
     ! Local variables
     integer :: jbnab2ch(mx_absb)
     integer :: k, k_in_part, k_in_halo, nbkbeg, j, jpart, jseq

--- a/src/multiply_kernel_ompGemm.f90
+++ b/src/multiply_kernel_ompGemm.f90
@@ -149,12 +149,12 @@ contains
     real(double) :: c(lenc)
     integer, optional :: debug
     ! Remote indices
-    integer(integ) :: ib_nd_acc(mx_part)
-    integer(integ) :: ibaddr(mx_part)
-    integer(integ) :: nbnab(mx_part)
-    integer(integ) :: ibpart(mx_part*mx_absb)
-    integer(integ) :: ibseq(mx_part*mx_absb)
-    integer(integ) :: bndim2(mx_part*mx_absb)
+    integer(integ), intent(in) :: ib_nd_acc(:)
+    integer(integ), intent(in) :: ibaddr(:)
+    integer(integ), intent(in) :: nbnab(:)
+    integer(integ), intent(in) :: ibpart(:)
+    integer(integ), intent(in) :: ibseq(:)
+    integer(integ), intent(in) :: bndim2(:)
     ! Local variables
     integer :: jbnab2ch(mx_absb)  ! Automatic array
     integer :: nbkbeg, k, k_in_part, k_in_halo, j, jpart, jseq
@@ -386,12 +386,12 @@ contains
     real(double) :: b(lenb)
     real(double) :: c(lenc)
     ! dimension declarations
-    integer :: ibaddr(mx_part)
-    integer :: ib_nd_acc(mx_part)
-    integer :: nbnab(mx_part)
-    integer :: ibpart(mx_part*mx_absb)
-    integer :: ibseq(mx_part*mx_absb)
-    integer :: bndim2(mx_part*mx_absb)
+    integer(integ), intent(in) :: ib_nd_acc(:)
+    integer(integ), intent(in) :: ibaddr(:)
+    integer(integ), intent(in) :: nbnab(:)
+    integer(integ), intent(in) :: ibpart(:)
+    integer(integ), intent(in) :: ibseq(:)
+    integer(integ), intent(in) :: bndim2(:)
     ! Local variables
     integer :: jbnab2ch(mx_absb)
     integer :: k, k_in_part, k_in_halo, nbkbeg, j, jpart, jseq

--- a/src/multiply_kernel_ompGemm_m.f90
+++ b/src/multiply_kernel_ompGemm_m.f90
@@ -149,12 +149,12 @@ contains
     real(double) :: c(lenc)
     integer, optional :: debug
     ! Remote indices
-    integer(integ) :: ib_nd_acc(mx_part)
-    integer(integ) :: ibaddr(mx_part)
-    integer(integ) :: nbnab(mx_part)
-    integer(integ) :: ibpart(mx_part*mx_absb)
-    integer(integ) :: ibseq(mx_part*mx_absb)
-    integer(integ) :: bndim2(mx_part*mx_absb)
+    integer(integ), intent(in) :: ib_nd_acc(:)
+    integer(integ), intent(in) :: ibaddr(:)
+    integer(integ), intent(in) :: nbnab(:)
+    integer(integ), intent(in) :: ibpart(:)
+    integer(integ), intent(in) :: ibseq(:)
+    integer(integ), intent(in) :: bndim2(:)
     ! Local variables
     integer :: jbnab2ch(mx_absb)  ! Automatic array
     integer :: nbkbeg, k, k_in_part, k_in_halo, j, jpart, jseq
@@ -173,6 +173,7 @@ contains
     maxnd2 = maxval(bndim2)
     maxnd3 = maxval(ahalo%ndimj)
     maxlen = maxval(nbnab) * maxnd2
+    !write(*,*) maxnd1, maxnd2, maxnd3, maxlen
     allocate(tempa(maxnd1,maxnd3), tempc(maxnd1,maxlen), tempb(maxnd3,maxlen))
     tempa = zero
     tempb = zero
@@ -391,12 +392,12 @@ contains
     real(double) :: b(lenb)
     real(double) :: c(lenc)
     ! dimension declarations
-    integer :: ibaddr(mx_part)
-    integer :: ib_nd_acc(mx_part)
-    integer :: nbnab(mx_part)
-    integer :: ibpart(mx_part*mx_absb)
-    integer :: ibseq(mx_part*mx_absb)
-    integer :: bndim2(mx_part*mx_absb)
+    integer(integ), intent(in) :: ib_nd_acc(:)
+    integer(integ), intent(in) :: ibaddr(:)
+    integer(integ), intent(in) :: nbnab(:)
+    integer(integ), intent(in) :: ibpart(:)
+    integer(integ), intent(in) :: ibseq(:)
+    integer(integ), intent(in) :: bndim2(:)
     ! Local variables
     integer :: jbnab2ch(mx_absb)
     integer :: k, k_in_part, k_in_halo, nbkbeg, j, jpart, jseq
@@ -414,6 +415,7 @@ contains
     maxnd2 = maxval(bndim2)
     maxnd3 = maxval(ahalo%ndimj)
     maxlen = maxval(nbnab) * maxnd2
+    !write(*,*) maxnd1, maxnd2, maxnd3, maxlen
     allocate(tempb(maxnd3,maxlen), tempc(maxlen,maxnd1))
     tempb = zero
     tempc = zero

--- a/src/multiply_kernel_ompGemm_m.f90
+++ b/src/multiply_kernel_ompGemm_m.f90
@@ -173,7 +173,6 @@ contains
     maxnd2 = maxval(bndim2)
     maxnd3 = maxval(ahalo%ndimj)
     maxlen = maxval(nbnab) * maxnd2
-    !write(*,*) maxnd1, maxnd2, maxnd3, maxlen
     allocate(tempa(maxnd1,maxnd3), tempc(maxnd1,maxlen), tempb(maxnd3,maxlen))
     tempa = zero
     tempb = zero
@@ -415,7 +414,6 @@ contains
     maxnd2 = maxval(bndim2)
     maxnd3 = maxval(ahalo%ndimj)
     maxlen = maxval(nbnab) * maxnd2
-    !write(*,*) maxnd1, maxnd2, maxnd3, maxlen
     allocate(tempb(maxnd3,maxlen), tempc(maxlen,maxnd1))
     tempb = zero
     tempc = zero

--- a/src/multiply_module.f90
+++ b/src/multiply_module.f90
@@ -240,6 +240,8 @@ contains
              lenb_rem = a_b_c%comms%ilen3rec(ipart,nnode)
           end if
           allocate(b_rem(lenb_rem))
+          part_array = 0
+          b_rem = zero
           call prefetch(kpart,a_b_c%ahalo,a_b_c%comms,a_b_c%bmat,icall,&
                n_cont,part_array,a_b_c%bindex,b_rem,lenb_rem,b,myid,ilen2,&
                mx_msg_per_part,a_b_c%parts,a_b_c%prim,a_b_c%gcs,(recv_part(nnode)-1)*2)


### PR DESCRIPTION
Closes #280 

Uses assumed shape arrays for remote index arrays. These can vary in size and using a fixed size leads to accessing uninitialized memory.

Edit: I wanted to clarify that the inputs you gave in #292 still fail for me on all multiply kernels. So I'm not claiming to fix *that* issue. But I discovered a different issue and I'm fixing it :grinning: 

Edit2: The reason the inputs from #292 fail for me is that my machine runs out of memory. Based on our last discussion that is to be expected with the size of the problem.