### PR TITLE
Add ID strings to matrix multiplication kernels and write out

### DIFF
--- a/src/initial_read_module.f90
+++ b/src/initial_read_module.f90
@@ -2639,6 +2639,7 @@ contains
     use control,    only: MDn_steps
     use md_control, only: md_ensemble
     use omp_module, only: init_threads
+    use multiply_kernel, only: kernel_id
 
     implicit none
 
@@ -2841,7 +2842,7 @@ contains
     else if (threads==1) then
        write(io_lun,fmt="(/4x,'The calculation will be performed on ',i5,' thread')") threads
     end if
-    
+    write(io_lun,fmt='(/4x,"Using the ",a," matrix multiplication kernel")') kernel_id
     if(.NOT.flag_diagonalisation) &
          write(io_lun,fmt='(10x,"Density Matrix range  = ",f7.4,1x,a2)') &
          dist_conv*r_c, d_units(dist_units)

--- a/src/multiply_kernel_default.f90
+++ b/src/multiply_kernel_default.f90
@@ -26,6 +26,8 @@
 !!
 module multiply_kernel
 
+  character(len=*), parameter :: kernel_id = "default"
+
 !!*****
 
 contains

--- a/src/multiply_kernel_gemm.f90
+++ b/src/multiply_kernel_gemm.f90
@@ -26,6 +26,8 @@
 !!
 module multiply_kernel
 
+  character(len=*), parameter :: kernel_id = "gemm"
+
 !!*****
 
 contains

--- a/src/multiply_kernel_ompDoii.f90
+++ b/src/multiply_kernel_ompDoii.f90
@@ -26,6 +26,8 @@
 !!
 module multiply_kernel
 
+  character(len=*), parameter :: kernel_id = "ompDoii"
+
 !!*****
 
 contains

--- a/src/multiply_kernel_ompDoik.f90
+++ b/src/multiply_kernel_ompDoik.f90
@@ -26,6 +26,8 @@
 !!
 module multiply_kernel
 
+  character(len=*), parameter :: kernel_id = "ompDoik"
+
 !!*****
 
 contains

--- a/src/multiply_kernel_ompDoji.f90
+++ b/src/multiply_kernel_ompDoji.f90
@@ -26,6 +26,8 @@
 !!
 module multiply_kernel
 
+  character(len=*), parameter :: kernel_id = "ompDoji"
+
 !!*****
 
 contains

--- a/src/multiply_kernel_ompDojk.f90
+++ b/src/multiply_kernel_ompDojk.f90
@@ -26,6 +26,8 @@
 !!
 module multiply_kernel
 
+  character(len=*), parameter :: kernel_id = "ompDojk"
+
 !!*****
 
 contains

--- a/src/multiply_kernel_ompGemm.f90
+++ b/src/multiply_kernel_ompGemm.f90
@@ -26,6 +26,8 @@
 !!
 module multiply_kernel
 
+  character(len=*), parameter :: kernel_id = "ompGemm"
+
 !!*****
 
 contains

--- a/src/multiply_kernel_ompGemm_m.f90
+++ b/src/multiply_kernel_ompGemm_m.f90
@@ -26,6 +26,8 @@
 !!
 module multiply_kernel
 
+  character(len=*), parameter :: kernel_id = "ompGemm_m"
+
 !!*****
 
 contains

--- a/src/multiply_kernel_ompTsk.f90
+++ b/src/multiply_kernel_ompTsk.f90
@@ -26,6 +26,8 @@
 !!
 module multiply_kernel
 
+  character(len=*), parameter :: kernel_id = "ompTsk"
+
 !!*****
 
 contains


### PR DESCRIPTION
This enables us to see which matrix multiplication kernel is being used; given that the code changes with kernel, I think that this record is important.