### PR TITLE
Change distance criteria to be consistent

### DIFF
--- a/src/matrix_elements_module.f90
+++ b/src/matrix_elements_module.f90
@@ -259,6 +259,7 @@ contains
     ! Module usage
     use datatypes
     use basic_types
+    use numbers, ONLY: RD_ERR
     use matrix_module
     use GenComms, ONLY: cq_abort
     use global_module, ONLY: id_glob, species_glob, sf, nlpf, paof, napf
@@ -277,7 +278,6 @@ contains
     integer :: inp, cumu_ndims, neigh_spec
     integer :: nn,j,np,ni,ist
     real(double) :: rcutsq,dx,dy,dz
-    real(double), parameter :: tol=1.0e-8_double
 
     ! Check that prim and gcs are correctly set up
     if((.NOT.ASSOCIATED(gcs%xcover)).OR. &
@@ -322,7 +322,7 @@ contains
                       dx=gcs%xcover(gcs%icover_ibeg(np)+ni-1)-prim%xprim(inp)
                       dy=gcs%ycover(gcs%icover_ibeg(np)+ni-1)-prim%yprim(inp)
                       dz=gcs%zcover(gcs%icover_ibeg(np)+ni-1)-prim%zprim(inp)
-                      if(dx*dx+dy*dy+dz*dz<rcutsq-tol) then
+                      if(dx*dx+dy*dy+dz*dz<rcutsq-RD_ERR) then
                          amat(nn)%n_nab(j)=amat(nn)%n_nab(j)+1
                          !write(io_lun,*) 'Neighbour: ',j,amat(nn)%n_nab(j)
                          if(amat(nn)%n_nab(j).gt.amat(nn)%mx_abs) then
@@ -412,6 +412,7 @@ contains
     ! Module usage
     use datatypes
     use basic_types
+    use numbers, ONLY: RD_ERR
     use matrix_module
     use GenComms, ONLY: cq_abort
     use global_module, ONLY: sf
@@ -432,7 +433,6 @@ contains
     integer :: nn,j,np,ni
     integer :: tot_nabs, nabs_of_atom, mx_abs_nabs
     real(double) :: rcutsq,dx,dy,dz
-    real(double), parameter :: tol=1.0e-8_double
 
     ! Check that prim and gcs are correctly set up
     if((.NOT.ASSOCIATED(gcs%xcover)).OR. &
@@ -466,7 +466,7 @@ contains
                       dx=gcs%xcover(gcs%icover_ibeg(np)+ni-1)-prim%xprim(inp)
                       dy=gcs%ycover(gcs%icover_ibeg(np)+ni-1)-prim%yprim(inp)
                       dz=gcs%zcover(gcs%icover_ibeg(np)+ni-1)-prim%zprim(inp)
-                      if(dx*dx+dy*dy+dz*dz<rcutsq-tol) then
+                      if(dx*dx+dy*dy+dz*dz<rcutsq-RD_ERR) then
                          nabs_of_atom = nabs_of_atom + 1
                          tot_nabs = tot_nabs + 1
                       endif

--- a/src/set_blipgrid_module.f90
+++ b/src/set_blipgrid_module.f90
@@ -415,7 +415,7 @@ contains
 
                 ! if(distsq < rcutsq) then  ! If it is a neighbour block,...
                 ! if(distsq < rcutsq+very_small) then  ! If it is a neighbour block,...
-                if(distsq < rcutsq(spec)+RD_ERR) then  ! If it is a neighbour block,...
+                if(distsq < rcutsq(spec)-RD_ERR) then  ! If it is a neighbour block,...
 
                    ! nxmin etc. (those will be used in BtoG trans.)
                    if(naba_blk%no_naba_blk(inp)==0) then
@@ -626,7 +626,7 @@ contains
                 zmax= zmin+ dcellz_block -dcellz_grid
                 call distsq_blk_atom&
                      (xatom,yatom,zatom,xmin,xmax,ymin,ymax,zmin,zmax,distsq)
-                if(distsq < rcutsq(spec)+RD_ERR) then  ! If it is a neighbour block,...
+                if(distsq < rcutsq(spec)-RD_ERR) then  ! If it is a neighbour block,...
 
                    ind_block= BCS_blocks%lab_cell(iblock)  !CC in a sim. cell
                    if(ind_block > blocks%mx_gcell) call cq_abort(' ERROR: ind_block in get_naba_BCSblk',ind_block,blocks%mx_gcell)
@@ -845,7 +845,7 @@ contains
                 call distsq_blk_atom &
                      (xatom,yatom,zatom,xmin,xmax,ymin,ymax,zmin,zmax,distsq)
                 spec = species_glob( id_glob( parts%icell_beg(DCS_parts%lab_cell(np)) +ni-1 ))
-                if(distsq<rcutsq(spec)+RD_ERR) then
+                if(distsq<rcutsq(spec)-RD_ERR) then
                 !if(distsq < rcutsq) then  ! have found a naba atom
                    ia=ia+1             ! seq. no. of naba atoms for iprim_blk
                    halo_set%ihalo(icover)=1     ! icover-th atom is a halo atom
@@ -1093,7 +1093,7 @@ contains
                 call distsq_blk_atom(xatom,yatom,zatom,xmin,xmax,ymin,ymax,zmin,zmax,distsq)
                 spec = species_glob( id_glob( parts%icell_beg(DCS_parts%lab_cell(np)) +ni-1 ))
 
-                if(distsq < rcutsq(spec)+RD_ERR) then  ! have found a naba atom
+                if(distsq < rcutsq(spec)-RD_ERR) then  ! have found a naba atom
                    ia=ia+1          
                    atoms = .true.
                    ihalo(icover) = 1

--- a/src/set_bucket_module.f90
+++ b/src/set_bucket_module.f90
@@ -593,7 +593,7 @@ contains
                         !        commented by TM 18Oct2006
    
                            distsq=(xmu-xnu)**2+(ymu-ynu)**2+(zmu-znu)**2
-                           if(distsq < rcutsq ) then
+                           if(distsq < rcutsq -RD_ERR ) then
                               if(loc_bucket%i_h2d(ind_halo2,ind_halo1) == 0) then !new pair
                                  npair=npair+1
                                  loc_bucket%i_h2d(ind_halo2,ind_halo1)=npair


### PR DESCRIPTION
In finding matrix elements, we now check for r2 < rcut2 - RD_ERR in all routines (before we sometimes used a locally defined tolerance, and in some places we had + instead of -)

I think that this was the source of the error (my guess is that the change in `set_bucket_module.f90` was the key one when compared to `matrix_elements_module.f90` but I'm not sure).