### PR TITLE
Properly abort the calculation if wrong method for variable temperatu…

### DIFF
--- a/src/control.f90
+++ b/src/control.f90
@@ -847,7 +847,7 @@ contains
            if(inode==ionode) &
              write(*,*) 'Wrong method for variable temperature. Stopping.. (',trim(md_variable_temperature_method),' != "linear")'
 
-           exit
+           call cq_abort("Wrong method for variable temperature")
 
          end if
 

--- a/src/control.f90
+++ b/src/control.f90
@@ -841,16 +841,6 @@ contains
 
        if (flag_variable_temperature) then
 
-         ! At present, only linear evolution is supported
-         if (md_variable_temperature_method .ne. 'linear') then
-
-           if(inode==ionode) &
-             write(*,*) 'Wrong method for variable temperature. Stopping.. (',trim(md_variable_temperature_method),' != "linear")'
-
-           call cq_abort("Wrong method for variable temperature")
-
-         end if
-
          ! At a given time step, update T_ext and ke_target
          ! Temperature evolves linearly from md_initial_temperature to md_final_temperature by step of temp_change_step
          ! Stops when target temperature has been reached (i.e. abs(dT) < abs(temp_change_step) )

--- a/src/initial_read_module.f90
+++ b/src/initial_read_module.f90
@@ -2299,6 +2299,19 @@ contains
     ! Variable temperature
     flag_variable_temperature = fdf_boolean('MD.VariableTemperature', .false.)
     md_variable_temperature_method = fdf_string(20, 'MD.VariableTemperatureMethod', 'linear')
+
+    ! Verify that a method for variable temperature is valid
+    if (flag_variable_temperature) then
+      ! At present, only linear evolution is supported
+      if (md_variable_temperature_method .ne. 'linear') then
+        if(inode==ionode) then
+          write(io_lun,fmt='(6x, "Wrong method for variable temperature: ", a, " != linear. Stopping ..." )') &
+            trim(md_variable_temperature_method)
+        end if
+        call cq_abort("Wrong method for variable temperature")
+      end if
+    end if
+
     md_variable_temperature_rate = fdf_double('MD.VariableTemperatureRate', 0.0_double)
     md_initial_temperature = fdf_double('MD.InitialTemperature',temp_ion)
     md_final_temperature = fdf_double('MD.FinalTemperature',temp_ion)

--- a/src/initial_read_module.f90
+++ b/src/initial_read_module.f90
@@ -2303,7 +2303,7 @@ contains
     ! Verify that a method for variable temperature is valid
     if (flag_variable_temperature) then
       ! At present, only linear evolution is supported
-      if (md_variable_temperature_method .ne. 'linear') then
+      if(.not.leqi(md_variable_temperature_method(1:6),'linear')) then
         if(inode==ionode) then
           write(io_lun,fmt='(6x, "Wrong method for variable temperature: ", a, " != linear. Stopping ..." )') &
             trim(md_variable_temperature_method)


### PR DESCRIPTION
Related to #316 

> Then, please use cq_abort.
If you use exit here, it would just exit the do-loop, I think.

When a wrong method for variable temperature MD is set, the program should abort and not just exit the loop.

Solution: Only the `linear` method is accepted. Any other value will lead to error message and CONQUEST will abort:

<img width="674" alt="image" src="https://github.com/OrderN/CONQUEST-release/assets/59640670/7c04044f-b259-4378-8b60-84fa1774a6e6">
