### PR TITLE
276 use blas

### DIFF
--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -936,7 +936,7 @@ contains
          exx_psolver, exx_pscheme, &         
          unit_exx_debug
     !
-    use exx_types, only: phi_i, phi_j, phi_k, phi_l, &
+    use exx_types, only: phi_i_1d_buffer, phi_j, phi_k, phi_l, &
          Phy_k, Ome_kj_1d_buffer, &
          work_in_3d, work_out_3d
     use exx_types, only: exx_alloc

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -1199,22 +1199,6 @@ contains
                          !
                          do nsf3 = 1, ia%nsup
                             !
-                           !  exx_mat_elem = zero
-                           !  !
-                           !  do r = 1, 2*extent+1
-                           !     do s = 1, 2*extent+1
-                           !        do t = 1, 2*extent+1                         
-
-                           !           exx_mat_elem = exx_mat_elem &                                    
-                           !                + phi_i(t,s,r,nsf3)    &
-                           !                * Ome_kj_reduced(t,s,r) * dv
-
-                           !        end do
-                           !     end do
-                           !  end do
-                           !  !
-                           !  c(ncaddr + nsf3 - 1) = c(ncaddr + nsf3 - 1) + exx_mat_elem
-
                             c(ncaddr + nsf3 - 1) = c(ncaddr + nsf3 - 1) + dot((2*extent+1)**3, phi_i(:,:,:,nsf3), 1, Ome_kj, 1) * dv
                             !
                          end do ! nsf3 = 1, ia%nsup

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -1122,7 +1122,7 @@ contains
           if ( exx_alloc ) call exx_mem_alloc(extent,ia%nsup,0,'phi_i_1d_buffer','alloc')
           print *, "Allocated phi_i_1d_buffer"
           phi_i(1:2*extent+1, 1:2*extent+1, 1:2*extent+1, 1:ia%nsup) => phi_i_1d_buffer
-          print *, "pointed phi_i at phi_i_1d_buffer"^
+          print *, "pointed phi_i at phi_i_1d_buffer"
           !
           call exx_phi_on_grid(inode,ia%ip,ia%spec,extent, &
                ia%xyz,ia%nsup,phi_i,r_int,xyz_zero)    

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -1169,12 +1169,12 @@ contains
                    Ome_kj(1:2*extent+1, 1:2*extent+1, 1:2*extent+1) => Ome_kj_1d_buffer
                    !
                    call start_timer(tmr_std_exx_accumul)
-                   !$omp parallel do schedule(runtime) collapse(2) default(none) reduction(+: c)              &
-                   !$omp     shared(kg,jb,tmr_std_exx_poisson,tmr_std_exx_accumul,Phy_k,phi_j,phi_k,ncbeg,ia, &
-                   !$omp            tmr_std_exx_matmult,ewald_pot,phi_i,exx_psolver,exx_pscheme,extent,dv,    &
-                   !$omp            ewald_rho,inode,pulay_radius,p_omega,p_gauss,w_gauss,reckernel_3d,r_int)  &
-                   !$omp     private(nsf1,nsf2,work_out_3d,work_in_3d,ewald_charge,Ome_kj,ncaddr,nsf3,        &
-                   !$omp             exx_mat_elem,r,s,t)
+                   !$omp parallel do schedule(runtime) collapse(2) default(none) reduction(+: c) &
+                   !$omp     shared(kg,jb,tmr_std_exx_poisson,tmr_std_exx_accumul,Phy_k,phi_j,phi_k,ncbeg,ia,tmr_std_exx_matmult,ewald_pot,phi_i, &
+                   !$omp            exx_psolver,exx_pscheme,extent,dv,ewald_rho,inode,pulay_radius,p_omega,p_gauss,w_gauss,reckernel_3d,r_int) &
+                   !$omp     private(nsf1,nsf2,work_out_3d,work_in_3d,ewald_charge, &
+                   !$omp             ncaddr,nsf3,exx_mat_elem,r,s,t) &
+                   !$omp     firstprivate(Ome_kj)
                    do nsf1 = 1, kg%nsup
                       do nsf2 = 1, jb%nsup
 

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -1206,7 +1206,6 @@ contains
                    end do ! nsf1 = 1, kg%nsup
                    !$omp end do
                    !$omp end parallel
-                   call stop_timer(tmr_std_exx_accumul,.true.)
                    !
                    call stop_timer(tmr_std_exx_accumul,.true.)
                    !

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -1120,10 +1120,13 @@ contains
           !print*, 'i',i, 'global_num',ia%ip,'spe',ia%spec
           !
           if ( exx_alloc ) call exx_mem_alloc(extent,ia%nsup,0,'phi_i_1d_buffer','alloc')
+          print *, "Allocated phi_i_1d_buffer"
           phi_i(1:2*extent+1, 1:2*extent+1, 1:2*extent+1, 1:ia%nsup) => phi_i_1d_buffer
+          print *, "pointed phi_i at phi_i_1d_buffer"^
           !
           call exx_phi_on_grid(inode,ia%ip,ia%spec,extent, &
-               ia%xyz,ia%nsup,phi_i,r_int,xyz_zero)             
+               ia%xyz,ia%nsup,phi_i,r_int,xyz_zero)    
+          print *, "populated phi_i"        
           !
           !print*, size(chalo%i_h2d), shape(chalo%i_h2d)
           ! 
@@ -1202,6 +1205,7 @@ contains
                             c(ncaddr + nsf3 - 1) = c(ncaddr + nsf3 - 1) + dot((2*extent+1)**3, phi_i(:,:,:,nsf3), 1, Ome_kj, 1) * dv
                             !
                          end do ! nsf3 = 1, ia%nsup
+                         print *, nsf1, nsf2, "calculated c"
                          !
                       end do ! nsf2 = 1, jb%nsup
                    end do ! nsf1 = 1, kg%nsup
@@ -1209,7 +1213,7 @@ contains
                    !
                    call stop_timer(tmr_std_exx_accumul,.true.)
                    !
-                   if ( exx_alloc ) call exx_mem_alloc(extent,0,0,'Ome_kj','dealloc')
+                   if ( exx_alloc ) call exx_mem_alloc(extent,0,0,'Ome_kj_1d_buffer','dealloc')
                    if ( exx_alloc ) call exx_mem_alloc(extent,jb%nsup,0,'phi_j','dealloc')
                    !
                 end if ! ( ncbeg /=0 )
@@ -1226,7 +1230,7 @@ contains
 !!$ ****[ i end loop ]****
 !!$
           !
-          if ( exx_alloc ) call exx_mem_alloc(extent,ia%nsup,0,'phi_i','dealloc')
+          if ( exx_alloc ) call exx_mem_alloc(extent,ia%nsup,0,'phi_i_1d_buffer','dealloc')
           !
        end do ! End of i = 1, at%n_hnab(k_in_halo)
        !

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -917,6 +917,7 @@ contains
     use numbers,        only: zero, one
     use matrix_module,  only: matrix_halo, matrix_trans
     use global_module,  only: area_exx
+    use GenBlas,        only: dot
     !
     use basic_types,    only: primary_set
     use primary_module, only: bundle 
@@ -995,7 +996,7 @@ contains
 
    !  real(double), dimension(:), allocatable :: phi_i_1d_buffer
    !  real(double), :: Ome_kj_reduced_1d_buffer((2*extent+1)*(2*extent+1)*(2*extent+1))
-    real(double), pointer :: phi_i(:,:,:), Ome_kj_reduced(:,:,:)
+    real(double), pointer :: phi_i(:,:,:,:), Ome_kj_reduced(:,:,:)
     !
     type(prim_atomic_data)  :: ia !i_alpha
     type(neigh_atomic_data) :: jb !j_beta

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -1163,12 +1163,12 @@ contains
                    if ( exx_alloc ) call exx_mem_alloc(extent,0,0,'Ome_kj_1d_buffer','alloc')
                    !
                    call start_timer(tmr_std_exx_accumul)
-                   !$omp parallel default(none) reduction(+: c) &
+                   !$omp parallel default(none) reduction(+: c)                                               &
                    !$omp     shared(kg,jb,tmr_std_exx_poisson,tmr_std_exx_accumul,Phy_k,phi_j,phi_k,ncbeg,ia, &
                    !$omp            tmr_std_exx_matmult,ewald_pot,phi_i,exx_psolver,exx_pscheme,extent,dv,    &
                    !$omp            ewald_rho,inode,pulay_radius,p_omega,p_gauss,w_gauss,reckernel_3d,r_int)  &
                    !$omp     private(nsf1,nsf2,work_out_3d,work_in_3d,ewald_charge,Ome_kj_1d_buffer,Ome_kj,   &
-                   !$omp             ncaddr,nsf3,exx_mat_elem,r,s,t) &
+                   !$omp             ncaddr,nsf3,exx_mat_elem,r,s,t)
                    Ome_kj(1:2*extent+1, 1:2*extent+1, 1:2*extent+1) => Ome_kj_1d_buffer
                    !$omp do schedule(runtime) collapse(2)
                    do nsf1 = 1, kg%nsup

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -1164,11 +1164,11 @@ contains
                    !
                    call start_timer(tmr_std_exx_accumul)
                    !$omp parallel default(none) reduction(+: c) &
-                   !$omp     shared(kg,jb,tmr_std_exx_poisson,tmr_std_exx_accumul,Phy_k,phi_j,phi_k,ncbeg,ia,tmr_std_exx_matmult,ewald_pot,phi_i, &
-                   !$omp            exx_psolver,exx_pscheme,extent,dv,ewald_rho,inode,pulay_radius,p_omega,p_gauss,w_gauss,reckernel_3d,r_int) &
-                   !$omp     private(nsf1,nsf2,work_out_3d,work_in_3d,ewald_charge,Ome_kj_1d_buffer, &
+                   !$omp     shared(kg,jb,tmr_std_exx_poisson,tmr_std_exx_accumul,Phy_k,phi_j,phi_k,ncbeg,ia, &
+                   !$omp            tmr_std_exx_matmult,ewald_pot,phi_i,exx_psolver,exx_pscheme,extent,dv,    &
+                   !$omp            ewald_rho,inode,pulay_radius,p_omega,p_gauss,w_gauss,reckernel_3d,r_int)  &
+                   !$omp     private(nsf1,nsf2,work_out_3d,work_in_3d,ewald_charge,Ome_kj_1d_buffer,Ome_kj,   &
                    !$omp             ncaddr,nsf3,exx_mat_elem,r,s,t) &
-                   !$omp     firstprivate(Ome_kj)
                    Ome_kj(1:2*extent+1, 1:2*extent+1, 1:2*extent+1) => Ome_kj_1d_buffer
                    !$omp do schedule(runtime) collapse(2)
                    do nsf1 = 1, kg%nsup
@@ -1198,7 +1198,8 @@ contains
                          !
                          do nsf3 = 1, ia%nsup
                             !
-                            c(ncaddr + nsf3 - 1) = c(ncaddr + nsf3 - 1) + dot((2*extent+1)**3, phi_i(:,:,:,nsf3), 1, Ome_kj, 1) * dv
+                            c(ncaddr + nsf3 - 1) = c(ncaddr + nsf3 - 1) &
+                               + dot((2*extent+1)**3, phi_i(:,:,:,nsf3), 1, Ome_kj, 1) * dv
                             !
                          end do ! nsf3 = 1, ia%nsup
                          !

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -1120,13 +1120,10 @@ contains
           !print*, 'i',i, 'global_num',ia%ip,'spe',ia%spec
           !
           if ( exx_alloc ) call exx_mem_alloc(extent,ia%nsup,0,'phi_i_1d_buffer','alloc')
-          print *, "Allocated phi_i_1d_buffer"
           phi_i(1:2*extent+1, 1:2*extent+1, 1:2*extent+1, 1:ia%nsup) => phi_i_1d_buffer
-          print *, "pointed phi_i at phi_i_1d_buffer"
           !
           call exx_phi_on_grid(inode,ia%ip,ia%spec,extent, &
                ia%xyz,ia%nsup,phi_i,r_int,xyz_zero)    
-          print *, "populated phi_i"        
           !
           !print*, size(chalo%i_h2d), shape(chalo%i_h2d)
           ! 
@@ -1205,7 +1202,6 @@ contains
                             c(ncaddr + nsf3 - 1) = c(ncaddr + nsf3 - 1) + dot((2*extent+1)**3, phi_i(:,:,:,nsf3), 1, Ome_kj, 1) * dv
                             !
                          end do ! nsf3 = 1, ia%nsup
-                         print *, nsf1, nsf2, "calculated c"
                          !
                       end do ! nsf2 = 1, jb%nsup
                    end do ! nsf1 = 1, kg%nsup

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -344,7 +344,7 @@ contains
           !
           if ( scheme == 1 ) then
              call exx_mem_alloc(extent,maxsuppfuncs,0,'Phy_k','alloc')
-             call exx_mem_alloc(extent,maxsuppfuncs,maxsuppfuncs,'Ome_kj','alloc')       
+             call exx_mem_alloc(extent,maxsuppfuncs,maxsuppfuncs,'Ome_kj_1d_buffer','alloc')       
              !
           end if
           !
@@ -799,7 +799,7 @@ contains
           !
           if ( scheme == 1 ) then
              call exx_mem_alloc(extent,maxsuppfuncs,0,'Phy_k','dealloc')
-             call exx_mem_alloc(extent,maxsuppfuncs,maxsuppfuncs,'Ome_kj','dealloc')   
+             call exx_mem_alloc(extent,maxsuppfuncs,maxsuppfuncs,'Ome_kj_1d_buffer','dealloc')   
              !
           end if
           !
@@ -937,7 +937,7 @@ contains
          unit_exx_debug
     !
     use exx_types, only: phi_i, phi_j, phi_k, phi_l, &
-         Phy_k, Ome_kj, &
+         Phy_k, Ome_kj_1d_buffer, &
          work_in_3d, work_out_3d
     use exx_types, only: exx_alloc
     !
@@ -993,10 +993,8 @@ contains
     real(double), dimension(3) :: xyz_zero  = zero
     real(double)               ::   dr,dv,K_val
     real(double)               ::   exx_mat_elem
-
-   !  real(double), dimension(:), allocatable :: phi_i_1d_buffer
-   !  real(double), :: Ome_kj_reduced_1d_buffer((2*extent+1)*(2*extent+1)*(2*extent+1))
-    real(double), pointer :: phi_i(:,:,:,:), Ome_kj_reduced(:,:,:)
+    !
+    real(double), pointer :: phi_i(:,:,:,:), Ome_kj(:,:,:)
     !
     type(prim_atomic_data)  :: ia !i_alpha
     type(neigh_atomic_data) :: jb !j_beta
@@ -1163,13 +1161,12 @@ contains
                         jb%xyz,jb%nsup,phi_j,r_int,xyz_zero)             
                    !
                    if ( exx_alloc ) call exx_mem_alloc(extent,0,0,'Ome_kj_1d_buffer','alloc')
-                   Ome_kj(1:2*extent+1, 1:2*extent+1, 1:2*extent+1) => Ome_kj_1d_buffer
                    !
                    call start_timer(tmr_std_exx_accumul)
                    !$omp parallel default(none) reduction(+: c) &
                    !$omp     shared(kg,jb,tmr_std_exx_poisson,tmr_std_exx_accumul,Phy_k,phi_j,phi_k,ncbeg,ia,tmr_std_exx_matmult,ewald_pot,phi_i, &
                    !$omp            exx_psolver,exx_pscheme,extent,dv,ewald_rho,inode,pulay_radius,p_omega,p_gauss,w_gauss,reckernel_3d,r_int) &
-                   !$omp     private(nsf1,nsf2,work_out_3d,work_in_3d,ewald_charge,Ome_kj_reduced_1d_buffer, &
+                   !$omp     private(nsf1,nsf2,work_out_3d,work_in_3d,ewald_charge,Ome_kj_1d_buffer, &
                    !$omp             ncaddr,nsf3,exx_mat_elem,r,s,t) &
                    !$omp     firstprivate(Ome_kj)
                    Ome_kj(1:2*extent+1, 1:2*extent+1, 1:2*extent+1) => Ome_kj_1d_buffer

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -1119,7 +1119,7 @@ contains
           !
           !print*, 'i',i, 'global_num',ia%ip,'spe',ia%spec
           !
-          if ( exx_alloc ) call exx_mem_alloc(extent,ia%nsup,0,'phi_i','alloc')
+          if ( exx_alloc ) call exx_mem_alloc(extent,ia%nsup,0,'phi_i_1d_buffer','alloc')
           phi_i(1:2*extent+1, 1:2*extent+1, 1:2*extent+1, 1:ia%nsup) => phi_i_1d_buffer
           !
           call exx_phi_on_grid(inode,ia%ip,ia%spec,extent, &

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -1166,12 +1166,14 @@ contains
                    Ome_kj(1:2*extent+1, 1:2*extent+1, 1:2*extent+1) => Ome_kj_1d_buffer
                    !
                    call start_timer(tmr_std_exx_accumul)
-                   !$omp parallel do schedule(runtime) collapse(2) default(none) reduction(+: c) &
+                   !$omp parallel default(none) reduction(+: c) &
                    !$omp     shared(kg,jb,tmr_std_exx_poisson,tmr_std_exx_accumul,Phy_k,phi_j,phi_k,ncbeg,ia,tmr_std_exx_matmult,ewald_pot,phi_i, &
                    !$omp            exx_psolver,exx_pscheme,extent,dv,ewald_rho,inode,pulay_radius,p_omega,p_gauss,w_gauss,reckernel_3d,r_int) &
-                   !$omp     private(nsf1,nsf2,work_out_3d,work_in_3d,ewald_charge, &
+                   !$omp     private(nsf1,nsf2,work_out_3d,work_in_3d,ewald_charge,Ome_kj_reduced_1d_buffer, &
                    !$omp             ncaddr,nsf3,exx_mat_elem,r,s,t) &
                    !$omp     firstprivate(Ome_kj)
+                   Ome_kj(1:2*extent+1, 1:2*extent+1, 1:2*extent+1) => Ome_kj_1d_buffer
+                   !$omp do schedule(runtime) collapse(2)
                    do nsf1 = 1, kg%nsup
                       do nsf2 = 1, jb%nsup
 
@@ -1205,7 +1207,9 @@ contains
                          !
                       end do ! nsf2 = 1, jb%nsup
                    end do ! nsf1 = 1, kg%nsup
-                   !$omp end parallel do
+                   !$omp end do
+                   !$omp end parallel
+                   call stop_timer(tmr_std_exx_accumul,.true.)
                    !
                    call stop_timer(tmr_std_exx_accumul,.true.)
                    !

--- a/src/exx_memory.f90
+++ b/src/exx_memory.f90
@@ -98,12 +98,20 @@ contains
 !!$
           !
        case('phi_i') ! allocate phi_i for primary atom
-          allocate(phi_i_1d_buffer(nsf1*(2*extent+1)*(2*extent+1)*(2*extent+1)), STAT=stat)
+          allocate(phi_i(2*extent+1,2*extent+1,2*extent+1,nsf1), STAT=stat)
           if(stat/=0) call cq_abort('Error allocating memory to phi_i/exx !',stat)
           call reg_alloc_mem(area_exx,nsf1*(2*extent+1)*(2*extent+1)*(2*extent+1),&
                type_dbl,matrix,lun)
-          phi_i_1d_buffer = zero
+          phi_i = zero
           !write(*,*) '\phi_{i\alpha} allocated', shape(phi_i)
+          !
+          !
+       case('phi_i_1d_buffer') ! allocate phi_i for primary atom
+          allocate(phi_i_1d_buffer(nsf1*(2*extent+1)*(2*extent+1)*(2*extent+1)), STAT=stat)
+          if(stat/=0) call cq_abort('Error allocating memory to phi_i_1d_buffer/exx !',stat)
+          call reg_alloc_mem(area_exx,nsf1*(2*extent+1)*(2*extent+1)*(2*extent+1),&
+               type_dbl,matrix,lun)
+          phi_i_1d_buffer = zero
           !
           !
        case('phi_j') ! allocate phi_j for neighbour atom [Srange]
@@ -289,6 +297,14 @@ contains
        call start_timer(tmr_std_exx_dealloc)
        select case (matrix)
        case('phi_i')
+          deallocate(phi_i,STAT=stat)
+          if(stat/=0) call cq_abort('Error deallocating memory to phi_i/exx !',stat)
+          call reg_dealloc_mem(area_exx,nsf1*(2*extent+1)*(2*extent+1)*(2*extent+1),&
+               type_dbl,matrix,lun)
+          !write(*,*) '\phi_{i\alpha} deallocated'
+          !
+          !
+       case('phi_i_1d_buffer')
           deallocate(phi_i_1d_buffer,STAT=stat)
           if(stat/=0) call cq_abort('Error deallocating memory to phi_i_1d_buffer/exx !',stat)
           call reg_dealloc_mem(area_exx,nsf1*(2*extent+1)*(2*extent+1)*(2*extent+1),&

--- a/src/exx_memory.f90
+++ b/src/exx_memory.f90
@@ -21,7 +21,7 @@ module exx_memory
   use datatypes
 
   use exx_types,         ONLY: phi_i, phi_j,  phi_k,  phi_l
-  use exx_types,         ONLY: Phy_k, Ome_kj
+  use exx_types,         ONLY: Phy_k, Ome_kj_1d_buffer
 
   
   use exx_types,         ONLY: work_in_3d,work_out_3d 
@@ -102,7 +102,7 @@ contains
           if(stat/=0) call cq_abort('Error allocating memory to phi_i/exx !',stat)
           call reg_alloc_mem(area_exx,nsf1*(2*extent+1)*(2*extent+1)*(2*extent+1),&
                type_dbl,matrix,lun)
-          phi_i = zero
+          phi_i_1d_buffer = zero
           !write(*,*) '\phi_{i\alpha} allocated', shape(phi_i)
           !
           !
@@ -148,7 +148,7 @@ contains
           !write(unit,*) '\Ome_{k\gamma}_{j\beta} allocated'
           !
           !
-     case('Ome_kj_1d_buffer') ! allocate Ome_kj_1d_buffer
+       case('Ome_kj_1d_buffer') ! allocate Ome_kj_1d_buffer
           allocate(Ome_kj_1d_buffer((2*extent+1)*(2*extent+1)*(2*extent+1)), STAT=stat)
           if(stat/=0) call cq_abort('Error allocating memory to Ome_kj_1d_buffer/exx !',stat)
           call reg_alloc_mem(area_exx,(2*extent+1)*(2*extent+1)*(2*extent+1),&
@@ -289,8 +289,8 @@ contains
        call start_timer(tmr_std_exx_dealloc)
        select case (matrix)
        case('phi_i')
-          deallocate(phi_i,STAT=stat)
-          if(stat/=0) call cq_abort('Error deallocating memory to phi_i/exx !',stat)
+          deallocate(phi_i_1d_buffer,STAT=stat)
+          if(stat/=0) call cq_abort('Error deallocating memory to phi_i_1d_buffer/exx !',stat)
           call reg_dealloc_mem(area_exx,nsf1*(2*extent+1)*(2*extent+1)*(2*extent+1),&
                type_dbl,matrix,lun)
           !write(*,*) '\phi_{i\alpha} deallocated'
@@ -320,9 +320,9 @@ contains
           !write(*,*) '\phi_{l\delta} deallocated'
           !
           !
-       case('Ome_kj')
-          deallocate(Ome_kj,STAT=stat)
-          if(stat/=0) call cq_abort('Error deallocating memory to Ome_kj/exx !',stat)
+       case('Ome_kj_1d_buffer')
+          deallocate(Ome_kj_1d_buffer,STAT=stat)
+          if(stat/=0) call cq_abort('Error deallocating memory to Ome_kj_1d_buffer/exx !',stat)
           call reg_dealloc_mem(area_exx,(2*extent+1)*(2*extent+1)*(2*extent+1),&
                type_dbl,matrix,lun)
           !write(unit,*) '\Ome_{k\gamma}_{j\beta} deallocated'

--- a/src/exx_memory.f90
+++ b/src/exx_memory.f90
@@ -147,15 +147,6 @@ contains
 !!$
 !!$
           !
-       case('Ome_kj') ! allocate Ome_kj
-          allocate(Ome_kj(2*extent+1,2*extent+1,2*extent+1), STAT=stat)
-          if(stat/=0) call cq_abort('Error allocating memory to Ome_kj/exx !',stat)
-          call reg_alloc_mem(area_exx,(2*extent+1)*(2*extent+1)*(2*extent+1),&
-               type_dbl,matrix,lun)
-          Ome_kj = zero
-          !write(unit,*) '\Ome_{k\gamma}_{j\beta} allocated'
-          !
-          !
        case('Ome_kj_1d_buffer') ! allocate Ome_kj_1d_buffer
           allocate(Ome_kj_1d_buffer((2*extent+1)*(2*extent+1)*(2*extent+1)), STAT=stat)
           if(stat/=0) call cq_abort('Error allocating memory to Ome_kj_1d_buffer/exx !',stat)
@@ -341,7 +332,7 @@ contains
           if(stat/=0) call cq_abort('Error deallocating memory to Ome_kj_1d_buffer/exx !',stat)
           call reg_dealloc_mem(area_exx,(2*extent+1)*(2*extent+1)*(2*extent+1),&
                type_dbl,matrix,lun)
-          !write(unit,*) '\Ome_{k\gamma}_{j\beta} deallocated'
+          !write(unit,*) '\Ome_{k\gamma}_{j\beta}_1d_buffer deallocated'
 
        case('Phy_k')
           deallocate(Phy_k, STAT=stat)

--- a/src/exx_memory.f90
+++ b/src/exx_memory.f90
@@ -20,7 +20,7 @@ module exx_memory
 
   use datatypes
 
-  use exx_types,         ONLY: phi_i, phi_j,  phi_k,  phi_l
+  use exx_types,         ONLY: phi_i, phi_i_1d_buffer, phi_j,  phi_k,  phi_l
   use exx_types,         ONLY: Phy_k, Ome_kj_1d_buffer
 
   

--- a/src/exx_memory.f90
+++ b/src/exx_memory.f90
@@ -98,7 +98,7 @@ contains
 !!$
           !
        case('phi_i') ! allocate phi_i for primary atom
-          allocate(phi_i(2*extent+1,2*extent+1,2*extent+1,nsf1), STAT=stat)
+          allocate(phi_i_1d_buffer(nsf1*(2*extent+1)*(2*extent+1)*(2*extent+1)), STAT=stat)
           if(stat/=0) call cq_abort('Error allocating memory to phi_i/exx !',stat)
           call reg_alloc_mem(area_exx,nsf1*(2*extent+1)*(2*extent+1)*(2*extent+1),&
                type_dbl,matrix,lun)
@@ -146,6 +146,15 @@ contains
                type_dbl,matrix,lun)
           Ome_kj = zero
           !write(unit,*) '\Ome_{k\gamma}_{j\beta} allocated'
+          !
+          !
+     case('Ome_kj_1d_buffer') ! allocate Ome_kj_1d_buffer
+          allocate(Ome_kj_1d_buffer((2*extent+1)*(2*extent+1)*(2*extent+1)), STAT=stat)
+          if(stat/=0) call cq_abort('Error allocating memory to Ome_kj_1d_buffer/exx !',stat)
+          call reg_alloc_mem(area_exx,(2*extent+1)*(2*extent+1)*(2*extent+1),&
+               type_dbl,matrix,lun)
+          Ome_kj_1d_buffer = zero
+          !write(unit,*) '\Ome_{k\gamma}_{j\beta}_1d_buffer allocated'
           !
           !
        case('Phy_k')! allocate Phy_k

--- a/src/exx_types.f90
+++ b/src/exx_types.f90
@@ -62,8 +62,8 @@ module exx_types
   real(double), dimension(:,:,:,:),     allocatable         :: phi_l  
 
   ! Auxiliary densities and potentials
-  real(double), dimension(:),           allocatable :: Ome_kj_1d_buffer
-  real(double), dimension(:,:,:,:),     allocatable :: Phy_k
+  real(double), dimension(:),           allocatable, target :: Ome_kj_1d_buffer
+  real(double), dimension(:,:,:,:),     allocatable         :: Phy_k
 
 
   

--- a/src/exx_types.f90
+++ b/src/exx_types.f90
@@ -55,7 +55,7 @@ module exx_types
   !  end type fftw1d
 
   ! PAOs on grid
-  real(double), dimension(:),     allocatable :: phi_i_1d_buffer
+  real(double), dimension(:),     allocatable, target :: phi_i_1d_buffer
   real(double), dimension(:,:,:,:),     allocatable :: phi_i
   real(double), dimension(:,:,:,:),     allocatable :: phi_j
   real(double), dimension(:,:,:,:),     allocatable :: phi_k

--- a/src/exx_types.f90
+++ b/src/exx_types.f90
@@ -55,11 +55,11 @@ module exx_types
   !  end type fftw1d
 
   ! PAOs on grid
-  real(double), dimension(:),     allocatable, target :: phi_i_1d_buffer
-  real(double), dimension(:,:,:,:),     allocatable :: phi_i
-  real(double), dimension(:,:,:,:),     allocatable :: phi_j
-  real(double), dimension(:,:,:,:),     allocatable :: phi_k
-  real(double), dimension(:,:,:,:),     allocatable :: phi_l  
+  real(double), dimension(:,:,:,:),     allocatable         :: phi_i
+  real(double), dimension(:),           allocatable, target :: phi_i_1d_buffer
+  real(double), dimension(:,:,:,:),     allocatable         :: phi_j
+  real(double), dimension(:,:,:,:),     allocatable         :: phi_k
+  real(double), dimension(:,:,:,:),     allocatable         :: phi_l  
 
   ! Auxiliary densities and potentials
   real(double), dimension(:),           allocatable :: Ome_kj_1d_buffer

--- a/src/exx_types.f90
+++ b/src/exx_types.f90
@@ -56,12 +56,13 @@ module exx_types
 
   ! PAOs on grid
   real(double), dimension(:),     allocatable :: phi_i_1d_buffer
+  real(double), dimension(:,:,:,:),     allocatable :: phi_i
   real(double), dimension(:,:,:,:),     allocatable :: phi_j
   real(double), dimension(:,:,:,:),     allocatable :: phi_k
   real(double), dimension(:,:,:,:),     allocatable :: phi_l  
 
   ! Auxiliary densities and potentials
-  real(double), dimension(:,:,:),       allocatable :: Ome_kj_1d_buffer
+  real(double), dimension(:),           allocatable :: Ome_kj_1d_buffer
   real(double), dimension(:,:,:,:),     allocatable :: Phy_k
 
 

--- a/src/exx_types.f90
+++ b/src/exx_types.f90
@@ -55,13 +55,13 @@ module exx_types
   !  end type fftw1d
 
   ! PAOs on grid
-  real(double), dimension(:,:,:,:),     allocatable :: phi_i
+  real(double), dimension(:),     allocatable :: phi_i_1d_buffer
   real(double), dimension(:,:,:,:),     allocatable :: phi_j
   real(double), dimension(:,:,:,:),     allocatable :: phi_k
   real(double), dimension(:,:,:,:),     allocatable :: phi_l  
 
   ! Auxiliary densities and potentials
-  real(double), dimension(:,:,:),       allocatable :: Ome_kj
+  real(double), dimension(:,:,:),       allocatable :: Ome_kj_1d_buffer
   real(double), dimension(:,:,:,:),     allocatable :: Phy_k
 
 


### PR DESCRIPTION
## Description
- Updates the rst nested loop in the kernel to use a BLAS dot product
    - This required refactoring some allocatable arrays into 1d buffers and using pointer arrays to reference them.
- Some additional unused allocatable arrays were also removed

## Speedup plot
This plot shows the performance of test `test_004_isol_C2H4_4proc_PBE0CRI` for 1 mpi process
![276-use-blas](https://github.com/OrderN/CONQUEST-release/assets/61978554/30b2bc77-d3e7-4fc0-a56a-4eea00ed5ded)

