### PR TITLE
Updates to fix RTD and add information on restarting

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
 # Build documentation in the docs/ directory with Sphinx
 #sphinx:
 #  configuration: docs/CONQUEST-manual/conf.py
@@ -14,6 +19,5 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt

--- a/docs/groundstate.rst
+++ b/docs/groundstate.rst
@@ -295,7 +295,31 @@ find the energy.
 
 Go to :ref:`top <groundstate>`.
 
-.. _ gs_scf_adv:
+.. _gs_scf_restart:
+
+Restarting SCF
+~~~~~~~~~~~~~~
+
+The SCF cycle can be restarted from a previous density matrix or
+charge density, which may significantly speed up convergence.
+The density matrix is automatically written out in the files ``Kmatrix2.*`` or
+``Lmatrix2.*`` (depending on whether diagonalisation or linear scaling
+is being used).  These files are read in, and the initial
+charge density made from them by setting the flags:
+
+  ::
+
+   General.LoadDM T
+   SC.MakeInitialChargeFromK T
+
+The charge density is not written out by default; this can be changed by
+setting ``IO.DumpChargeDensity T`` which results in the files ``chden.nnn``
+being created.  To read these in as the initial charge density, the flag
+``General.LoadRho T`` should be set.
+
+Go to :ref:`top <groundstate>`.
+
+.. _gs_scf_adv:
 
 Advanced options
 ~~~~~~~~~~~~~~~~

--- a/docs/input_tags.rst
+++ b/docs/input_tags.rst
@@ -119,8 +119,9 @@ General.NewRun (*boolean*)
 
     *default*: T
 
-General.LoadL (*boolean*)
-    Specifies whether to load a previous L matrix from files
+General.LoadDM (*boolean*)
+    Specifies whether to load a previous density matrix (K or L depending on
+    whether diagonalisation or linear scaling are selected) from files
 
     *default*: F
 
@@ -532,6 +533,11 @@ SC.MetricFactor (*real*)
 
     *default*: 0.1
 
+SC.MakeInitialChargeFromK (*boolean*)
+    Flag determining whether initial charge is made from the density matrix
+
+    *default*: T
+    
 Go to :ref:`top <input_tags>`.
 
 .. _input_dm:

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -7,32 +7,6 @@ Installation
 You will need to download and compile the code before you can use it;
 we do not supply binaries.
 
-.. _install_spack:
-
-Installing with Spack
------------
-
-CONQUEST and all of its dependencies can be installed with `Spack<https://spack.io/>`_.
-The CONQUEST package requires Spack v0.21 or later. If Spack isn't available or up to date on your
-system, it is relatively straightforward to install it with user permissions following the
-`install instructions<https://spack.readthedocs.io/en/latest/getting_started.html#installation>`_.
-When setting up Spack on a new system, it is recommended to configure it to use available
-`system compilers<https://spack.readthedocs.io/en/latest/getting_started.html#compiler-configuration>`_
-and `system packages<https://spack.readthedocs.io/en/latest/getting_started.html#system-packages>`_.
-Once spack is installed and set up, install CONQUEST with:
-
-``spack install conquest``
-
-and load the ``Conquest`` executable to ``PATH`` with
-
-``spack load conquest``
-
-The build can be customized by adding options to the
-`Spack spec<https://spack.readthedocs.io/en/latest/basic_usage.html#specs-dependencies>`_ ``conquest``.
-The CONQUEST package includes variants for OpenMP support and different matrix multiplication kernels,
-please see the `Spack package<https://spack.readthedocs.io/en/latest/package_list.html#conquest>`_ for
-more details.
-
 .. _install_down:
 
 Downloading
@@ -49,6 +23,8 @@ Alternatively, it can be downloaded from GitHub as a zip file and
 unpacked:
 
 `<https://github.com/OrderN/CONQUEST-release/archive/master.zip>`_
+
+Go to :ref:`top <install>`
 
 .. _install_compile:
 
@@ -99,6 +75,8 @@ Once these are set, you should make the executable using ``make``.
 The ion file generation code is compiled using the same options
 required for the main code.
 
+Go to :ref:`top <install>`
+
 Multi-threading
 ~~~~~~~~~~~~~~~
 
@@ -107,3 +85,32 @@ CONQUEST can use OpenMP for multi-threading; some multi-threading is available t
 Compiler flags to enable OpenMP are dependent on the vendor, but should be specified via ``COMPFLAGS`` and ``LINKFLAGS`` in the ``system.make`` file.  If compiling with OpenMP then you should also change the variable ``OMP_DUMMY`` in the same file to be blank to enable the number of threads to be included in the output.
 
 On some systems, the default stack size for OpenMP is set to be rather small, and this can cause a segmentation fault when running with multiple threads.  We recommend testing the effect of the environment variable ``OMP_STACKSIZE`` (and suggest setting it to 50M or larger as a first test).
+
+Go to :ref:`top <install>`
+
+.. _install_spack:
+
+Installing with Spack
+-----------
+
+CONQUEST and all of its dependencies can be installed with `Spack <https://spack.io/>`_.
+The CONQUEST package requires Spack v0.21 or later. If Spack isn't available or up to date on your
+system, it is relatively straightforward to install it with user permissions following the
+`install instructions <https://spack.readthedocs.io/en/latest/getting_started.html#installation>`_.
+When setting up Spack on a new system, it is recommended to configure it to use available
+`system compilers <https://spack.readthedocs.io/en/latest/getting_started.html#compiler-configuration>`_
+and `system packages <https://spack.readthedocs.io/en/latest/getting_started.html#system-packages>`_.
+Once spack is installed and set up, install CONQUEST with:
+
+``spack install conquest``
+
+and load the ``Conquest`` executable to ``PATH`` with
+
+``spack load conquest``
+
+The build can be customized by adding options to the
+`Spack spec <https://spack.readthedocs.io/en/latest/basic_usage.html#specs-dependencies>`_ ``conquest``.
+The CONQUEST package includes variants for OpenMP support and different matrix multiplication kernels; more details can be found in the `Spack CONQUEST package <https://spack.readthedocs.io/en/latest/package_list.html#conquest>`_.
+
+Go to :ref:`top <install>`
+


### PR DESCRIPTION
Fix a problem with readthedocs setup, add information on restarting SCF from existing DM or charge density and fix formatting in Spack installation text.