### PR TITLE
Update versions of github actions

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -74,7 +74,7 @@ jobs:
             multiply_kernel: ompGemm_m
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
 
@@ -84,7 +84,7 @@ jobs:
         sudo apt install openmpi-bin libopenmpi-dev libfftw3-dev libblas3 liblapack3 libscalapack-openmpi-dev libxc-dev
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 


### PR DESCRIPTION
This updates the `checkout` and `setup-python` actions used in the CI workflow to their latest released versions. Silences the warnings in the github actions output.