### PR TITLE
Extract inner cri calc into separate subroutine

### DIFF
--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -641,6 +641,7 @@ contains
              if(stat/=0) call cq_abort('Error allocating memory toeris/exx !',stat)
              call reg_alloc_mem(area_exx, nb_eris, type_int,'eris',unit_memory_write)
              eris(kpart)%filter_eris = .true.
+             
              !
              ! Second dummy call for poor-man filtering of ERIs
              !
@@ -929,7 +930,6 @@ contains
        ! Backup eris parameters. Optional as they are only needed by eri function
        logical,               intent(in)            :: backup_eris
        real(double), pointer, intent(inout), OPTIONAL :: store_eris_inner(:,:)
-       
        integer      :: ncaddr, nsf3
        real(double) :: exx_mat_elem
 
@@ -962,7 +962,7 @@ contains
           if ( backup_eris ) then
              !
              ! eris(kpart)%store_eris( count ) = exx_mat_elem
-             store_eris_inner(nsf2, nsf3) = exx_mat_elem
+             store_eris_inner(nsf3, nsf2) = exx_mat_elem
              !
           else
              !
@@ -1423,14 +1423,13 @@ contains
     !
     dr = grid_spacing
     dv = dr**3
-    count = 1
+    count = 0
     !
 !!$
 !!$ ****[ k loop ]****
 !!$
     k_loop: do k = 1, ahalo%nh_part(kpart)
        !
-       write (*,*) kpart, ahalo%nh_part(kpart), k
        k_in_halo  = ahalo%j_beg(kpart) + k - 1
        k_in_part  = ahalo%j_seq(k_in_halo)
        nbkbeg     = ibaddr     (k_in_part) 
@@ -1607,8 +1606,8 @@ contains
                             Ome_kj(1:2*extent+1, 1:2*extent+1, 1:2*extent+1) => Ome_kj_1d_buffer
                             !
                             ! Point at the next block of eris to store and update counter 
-                            store_eris_inner(1:ia%nsup, 1:jb%nsup) => eris(kpart)%store_eris(count:count + (jb%nsup * ia%nsup))
-                            count = count + (jb%nsup * ia%nsup) + 1
+                            store_eris_inner(1:ia%nsup, 1:jb%nsup) => eris(kpart)%store_eris(count+1:count + (jb%nsup * ia%nsup))
+                            count = count + (jb%nsup * ia%nsup)
                             !
                             jb_loop: do nsf_jb = 1, jb%nsup
                                !

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -928,7 +928,7 @@ contains
        real(double),          intent(inout)         :: c(:)
        ! Backup eris parameters. Optional as they are only needed by eri function
        logical,               intent(in)            :: backup_eris
-       real(double), pointer, intent(out), OPTIONAL :: store_eris_inner(:,:)
+       real(double), pointer, intent(inout), OPTIONAL :: store_eris_inner(:,:)
        
        integer      :: ncaddr, nsf3
        real(double) :: exx_mat_elem
@@ -1607,7 +1607,7 @@ contains
                             Ome_kj(1:2*extent+1, 1:2*extent+1, 1:2*extent+1) => Ome_kj_1d_buffer
                             !
                             ! Point at the next block of eris to store and update counter 
-                            store_eris_inner(1:jb%nsup, 1:ia%nsup) => eris(kpart)%store_eris(count)
+                            store_eris_inner(1:jb%nsup, 1:ia%nsup) => eris(kpart)%store_eris(count:count + (jb%nsup * ia%nsup))
                             count = count + (jb%nsup * ia%nsup)
                             !
                             jb_loop: do nsf_jb = 1, jb%nsup

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -904,9 +904,9 @@ contains
   !
   ! To ensure thread safety, variables which are altered must be passed in as parameters rather than imported.
   ! TODO: Change name to something more descriptive
-  subroutine cri_eri_inner_calculation(nsf1_array, phi_i, Ome_kj, nsf1, nsf2, kpart, multiplier, &
-               ncaddr, ncbeg, ia_nsup, ewald_charge, work_out_3d, work_in_3d, c,         &
-               backup_eris, store_eris_inner) 
+  subroutine cri_eri_inner_calculation(nsf1_array, phi_i, Ome_kj, nsf1, nsf2, kpart, dv,  &
+               multiplier, ncaddr, ncbeg, ia_nsup, ewald_charge, work_out_3d, work_in_3d, &
+               c, backup_eris, store_eris_inner) 
 
        use exx_poisson, only: exx_v_on_grid, exx_ewald_charge
 
@@ -923,7 +923,7 @@ contains
        real(double), pointer, intent(in)            :: Ome_kj(:,:,:), phi_i(:,:,:,:)
        integer,               intent(in)            :: kpart, nsf1, nsf2             ! The indices of the loops from which this function is called 
        integer,               intent(in)            :: ncbeg, ia_nsup
-       real(double),          intent(in)            :: nsf1_array(:,:,:,:), multiplier
+       real(double),          intent(in)            :: nsf1_array(:,:,:,:), dv, multiplier
        real(double),          intent(out)           :: ewald_charge, work_out_3d(:,:,:), work_in_3d(:,:,:)
        real(double),          intent(inout)         :: c(:)
        ! Backup eris parameters. Optional as they are only needed by eri function
@@ -957,7 +957,7 @@ contains
        do nsf3 = 1, ia_nsup
           !
           ! Can we instead always store directly into store_eris_inner(nsf2, nsf3)?
-          exx_mat_elem = dot((2*extent+1)**3, phi_i(:,:,:,nsf3), 1, Ome_kj, 1) * multiplier
+          exx_mat_elem = dot((2*extent+1)**3, phi_i(:,:,:,nsf3), 1, Ome_kj, 1) * dv * multiplier
           !
           if ( backup_eris ) then
              !
@@ -1258,8 +1258,8 @@ contains
                    do nsf_kg = 1, kg%nsup
                       do nsf_ld = 1, jb%nsup
                          !
-                         call cri_eri_inner_calculation(Phy_k, phi_i, Ome_kj, nsf_kg, nsf_ld, kpart, dv,  &
-                                       ncaddr,  ncbeg, ia%nsup, ewald_charge, work_out_3d, work_in_3d, c, &
+                         call cri_eri_inner_calculation(Phy_k, phi_i, Ome_kj, nsf_kg, nsf_ld, kpart, dv, 1.0d0, &
+                                       ncaddr,  ncbeg, ia%nsup, ewald_charge, work_out_3d, work_in_3d, c,       &
                                        .false.)
                          !
                       end do ! nsf_ld = 1, jb%nsup
@@ -1623,7 +1623,7 @@ contains
                                jb_count = j_count + (nsf_jb - 1)
                                jb_count = jb_count * (ia%nsup - 1)
                                !
-                               call cri_eri_inner_calculation(phi_l, phi_i, Ome_kj, nsf_ld, nsf_jb, kpart, dv * K_val, &
+                               call cri_eri_inner_calculation(phi_l, phi_i, Ome_kj, nsf_ld, nsf_jb, kpart, dv, K_val, &
                                              ncaddr, ncbeg, ia%nsup, ewald_charge, work_out_3d, work_in_3d, c, &
                                              backup_eris, store_eris_inner)
                                !

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -1607,7 +1607,7 @@ contains
                             Ome_kj(1:2*extent+1, 1:2*extent+1, 1:2*extent+1) => Ome_kj_1d_buffer
                             !
                             ! Point at the next block of eris to store and update counter 
-                            store_eris_inner(1:jb%nsup, 1:ia%nsup) => eris(kpart)%store_eris(count:count + (jb%nsup * ia%nsup))
+                            store_eris_inner(1:ia%nsup, 1:jb%nsup) => eris(kpart)%store_eris(count:count + (jb%nsup * ia%nsup))
                             count = count + (jb%nsup * ia%nsup) + 1
                             !
                             jb_loop: do nsf_jb = 1, jb%nsup

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -1608,7 +1608,7 @@ contains
                             !
                             ! Point at the next block of eris to store and update counter 
                             store_eris_inner(1:jb%nsup, 1:ia%nsup) => eris(kpart)%store_eris(count:count + (jb%nsup * ia%nsup))
-                            count = count + (jb%nsup * ia%nsup)
+                            count = count + (jb%nsup * ia%nsup) + 1
                             !
                             jb_loop: do nsf_jb = 1, jb%nsup
                                !

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -1460,7 +1460,7 @@ contains
        !print*
        !
        ! The current state of count
-       k_count = (k - 1) * nbnab(k_in_part)
+       k_count = (k - 1) * (nbnab(k_in_part) - 1)
 !!$
 !!$ ****[ l do loop ]****
 !!$
@@ -1485,9 +1485,9 @@ contains
           !
           !  The current state of count
           ! l_count = (k - 1)      * nbnab(k_in_part) * ld%nsup + &
-          !         (l - 1)                         * ld%nsup
+          !           (l - 1)                         * ld%nsup
           l_count = k_count + (l - 1)
-          l_count = l_count * ld%nsup
+          l_count = l_count * (ld%nsup - 1)
           !
           ld_loop: do nsf_ld = 1, ld%nsup
              !
@@ -1498,7 +1498,7 @@ contains
              !         (l - 1)                         * ld%nsup * kg%nsup + &
              !         (nsf_ld - 1)                              * kg%nsup
              ld_count = l_count + (nsf_ld - 1)
-             ld_count = ld_count * kg%nsup
+             ld_count = ld_count * (kg%nsup - 1)
              !
              kg_loop: do nsf_kg = 1, kg%nsup                         
                 !
@@ -1510,11 +1510,11 @@ contains
                 !
                 ! The current state of count
                 ! kg_count = (k - 1)      * nbnab(k_in_part) * ld%nsup * kg%nsup * at%n_hnab(k_in_halo) + &
-                !         (l - 1)                         * ld%nsup * kg%nsup * at%n_hnab(k_in_halo) + &
-                !         (nsf_ld - 1)                              * kg%nsup * at%n_hnab(k_in_halo) + &
-                !         (nsf_kg - 1)                                        * at%n_hnab(k_in_halo)
+                !            (l - 1)                         * ld%nsup * kg%nsup * at%n_hnab(k_in_halo) + &
+                !            (nsf_ld - 1)                              * kg%nsup * at%n_hnab(k_in_halo) + &
+                !            (nsf_kg - 1)                                        * at%n_hnab(k_in_halo)
                 kg_count = ld_count + (nsf_kg - 1)
-                kg_count = kg_count * at%n_hnab(k_in_halo)
+                kg_count = kg_count * (at%n_hnab(k_in_halo) - 1)
                 !
 !!$
 !!$ ****[ i loop ]****
@@ -1545,12 +1545,12 @@ contains
                    !
                    ! The current state of count
                    ! i_count = (k - 1)      * nbnab(k_in_part) * ld%nsup * kg%nsup * at%n_hnab(k_in_halo) * nbnab(k_in_part) + &
-                   !         (l - 1)                         * ld%nsup * kg%nsup * at%n_hnab(k_in_halo) * nbnab(k_in_part) + &
-                   !         (nsf_ld - 1)                              * kg%nsup * at%n_hnab(k_in_halo) * nbnab(k_in_part) + &
-                   !         (nsf_kg - 1)                                        * at%n_hnab(k_in_halo) * nbnab(k_in_part) + &
-                   !         (i - 1)                                                                    * nbnab(k_in_part)
+                   !           (l - 1)                         * ld%nsup * kg%nsup * at%n_hnab(k_in_halo) * nbnab(k_in_part) + &
+                   !           (nsf_ld - 1)                              * kg%nsup * at%n_hnab(k_in_halo) * nbnab(k_in_part) + &
+                   !           (nsf_kg - 1)                                        * at%n_hnab(k_in_halo) * nbnab(k_in_part) + &
+                   !           (i - 1)                                                                    * nbnab(k_in_part)
                    i_count = kg_count + (i - 1)
-                   i_count = i_count * nbnab(k_in_part)
+                   i_count = i_count * (nbnab(k_in_part) - 1)
                    !
 !!$
 !!$ ****[ j loop ]****
@@ -1595,7 +1595,7 @@ contains
                             !           (i - 1)                                                                    * nbnab(k_in_part) * jb%nsup + &
                             !           (j - 1)                                                                                       * jb%nsup + &
                             j_count = i_count + (j - 1)
-                            j_count = j_count * jb%nsup
+                            j_count = j_count * (jb%nsup - 1)
                             !
                             Ome_kj(1:2*extent+1, 1:2*extent+1, 1:2*extent+1) => Ome_kj_1d_buffer
                             jb_loop: do nsf_jb = 1, jb%nsup
@@ -1609,7 +1609,7 @@ contains
                                !            (j - 1)                                                                                       * jb%nsup * ia%nsup + &
                                !            (nsf_jb - 1)                                                                                            * ia%nsup
                                jb_count = j_count + (nsf_jb - 1)
-                               jb_count = jb_count * ia%nsup
+                               jb_count = jb_count * (ia%nsup - 1)
                                !
                                call cri_eri_inner_calculation(phi_l, phi_i, Ome_kj, nsf_ld, nsf_jb, kpart, dv, ncaddr, ncbeg, &
                                              ia%nsup, backup_eris, jb_count, ewald_charge, work_out_3d, work_in_3d, c)

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -904,7 +904,7 @@ contains
   !
   ! To ensure thread safety, variables which are altered must be passed in as parameters rather than imported.
   ! TODO: Change name to something more descriptive
-  subroutine cri_eri_inner_calculation(nsf1_array, phi_i, Ome_kj, nsf1, nsf2, kpart, dv, &
+  subroutine cri_eri_inner_calculation(nsf1_array, phi_i, Ome_kj, nsf1, nsf2, kpart, multiplier, &
                ncaddr, ncbeg, ia_nsup, ewald_charge, work_out_3d, work_in_3d, c,         &
                backup_eris, store_eris_inner) 
 
@@ -923,7 +923,7 @@ contains
        real(double), pointer, intent(in)            :: Ome_kj(:,:,:), phi_i(:,:,:,:)
        integer,               intent(in)            :: kpart, nsf1, nsf2             ! The indices of the loops from which this function is called 
        integer,               intent(in)            :: ncbeg, ia_nsup
-       real(double),          intent(in)            :: nsf1_array(:,:,:,:), dv
+       real(double),          intent(in)            :: nsf1_array(:,:,:,:), multiplier
        real(double),          intent(out)           :: ewald_charge, work_out_3d(:,:,:), work_in_3d(:,:,:)
        real(double),          intent(inout)         :: c(:)
        ! Backup eris parameters. Optional as they are only needed by eri function
@@ -957,7 +957,7 @@ contains
        do nsf3 = 1, ia_nsup
           !
           ! Can we instead always store directly into store_eris_inner(nsf2, nsf3)?
-          exx_mat_elem = dot((2*extent+1)**3, phi_i(:,:,:,nsf3), 1, Ome_kj, 1) * dv
+          exx_mat_elem = dot((2*extent+1)**3, phi_i(:,:,:,nsf3), 1, Ome_kj, 1) * multiplier
           !
           if ( backup_eris ) then
              !
@@ -1623,7 +1623,7 @@ contains
                                jb_count = j_count + (nsf_jb - 1)
                                jb_count = jb_count * (ia%nsup - 1)
                                !
-                               call cri_eri_inner_calculation(phi_l, phi_i, Ome_kj, nsf_ld, nsf_jb, kpart, dv, &
+                               call cri_eri_inner_calculation(phi_l, phi_i, Ome_kj, nsf_ld, nsf_jb, kpart, dv * K_val, &
                                              ncaddr, ncbeg, ia%nsup, ewald_charge, work_out_3d, work_in_3d, c, &
                                              backup_eris, store_eris_inner)
                                !

--- a/src/exx_kernel_default.f90
+++ b/src/exx_kernel_default.f90
@@ -904,7 +904,7 @@ contains
   !
   ! To ensure thread safety, variables which are altered must be passed in as parameters rather than imported.
   ! TODO: Change name to something more descriptive
-  subroutine cri_eri_inner_calculation(nsf1_array, phi_i, Ome_kj, nsf1, nsf2, nsf3, kpart, dv, ncaddr, ncbeg, &
+  subroutine cri_eri_inner_calculation(nsf1_array, phi_i, Ome_kj, nsf1, nsf2, kpart, dv, ncaddr, ncbeg, &
                ia_nsup, backup_eris, start_count, ewald_charge, work_out_3d, work_in_3d, c) 
 
        use exx_poisson, only: exx_v_on_grid, exx_ewald_charge
@@ -1611,7 +1611,7 @@ contains
                                jb_count = j_count + (nsf_jb - 1)
                                jb_count = jb_count * ia%nsup
                                !
-                               call cri_eri_inner_calculation(phi_l, phi_i, Ome_kj, nsf_kg, nsf_jb, kpart, dv, ncaddr, ncbeg, &
+                               call cri_eri_inner_calculation(phi_l, phi_i, Ome_kj, nsf_ld, nsf_jb, kpart, dv, ncaddr, ncbeg, &
                                              ia%nsup, backup_eris, jb_count, ewald_charge, work_out_3d, work_in_3d, c)
                                !
                             end do jb_loop

--- a/src/exx_types.f90
+++ b/src/exx_types.f90
@@ -181,7 +181,7 @@ module exx_types
   end type store_eris
 
   ! Electron repulsion integrals
-  type(store_eris), dimension(:), allocatable :: eris
+  type(store_eris), dimension(:), allocatable, target :: eris
   
   type prim_atomic_data
      integer  :: pr

--- a/src/system/system.mac.make
+++ b/src/system/system.mac.make
@@ -1,0 +1,56 @@
+# This is an example system-specific makefile. You will need to adjust
+# it for the actual system you are running on.
+
+# Set compilers
+FC=/opt/homebrew/bin/mpifort
+
+# OpenMP flags
+# Set this to "OMPFLAGS= " if compiling without openmp
+# Set this to "OMPFLAGS= -fopenmp" if compiling with openmp
+OMPFLAGS= -fopenmp
+# Set this to "OMP_DUMMY = DUMMY" if compiling without openmp
+# Set this to "OMP_DUMMY = " if compiling with openmp
+OMP_DUMMY = 
+
+# Set BLAS and LAPACK libraries
+# MacOS X
+# BLAS= -lvecLibFort
+# Intel MKL use the Intel tool
+# Generic
+BLAS= -llapack -lblas
+# Full scalapack library call; remove -lscalapack if using dummy diag module.
+# If using OpenMPI, use -lscalapack-openmpi instead.
+# If using Cray-libsci, use -llibsci_cray_mpi instead.
+SCALAPACK = -lscalapack
+
+# LibXC: choose between LibXC compatibility below or Conquest XC library
+
+# Conquest XC library
+#XC_LIBRARY = CQ
+#XC_LIB =
+#XC_COMPFLAGS =
+
+# LibXC compatibility
+# Choose LibXC version: v4 (deprecated) or v5/6 (v5 and v6 have the same interface)
+#XC_LIBRARY = LibXC_v4
+XC_LIBRARY = LibXC_v5
+XC_LIB = -lxcf90 -lxc
+XC_COMPFLAGS = -I/opt/homebrew/Cellar/libxc/6.2.2/include
+
+# Set FFT library
+FFT_LIB=-lfftw3
+FFT_OBJ=fft_fftw3.o
+
+LIBS= $(FFT_LIB) $(XC_LIB) $(SCALAPACK) $(BLAS)
+
+# Compilation flags
+# NB for gcc10 you need to add -fallow-argument-mismatch
+COMPFLAGS= -fallow-argument-mismatch -O3 $(OMPFLAGS) $(XC_COMPFLAGS) -I/opt/homebrew/Cellar/openblas/0.3.27/include -I/opt/homebrew/Cellar/lapack/3.12.0/include -I/opt/homebrew/Cellar/fftw/3.3.10_1/include
+
+# Linking flags
+LINKFLAGS= $(OMPFLAGS) -L/opt/homebrew/Cellar/openblas/0.3.27/lib -L/opt/homebrew/Cellar/lapack/3.12.0/lib -L/opt/homebrew/Cellar/fftw/3.3.10_1/lib -L/opt/homebrew/Cellar/libxc/6.2.2/lib -L/opt/homebrew/Cellar/scalapack/2.2.0_1/lib
+
+# Matrix multiplication kernel type
+MULT_KERN = default
+# Use dummy DiagModule or not
+DIAG_DUMMY =


### PR DESCRIPTION
I believe the code within the `do nsf2 = 1, jb%nsup` loop of `m_kern_exx_cri` and `m_kern_exx_eri` is almost identical. Therefore, we should be able to extract this into a subroutine and therefore get the gain of using BLAS and any other optimisation in one place.

The current issue is that in `m_ker_exx_eri` there is an option to `backup_eris`. If true, this contiguously accesses a 1D array via `eris(kpart)%store_eris(count)`. With the new OpenMP thread implementation we no longer access these elements in this order. 