### PR TITLE
atom ordering in velocity.dat

### DIFF
--- a/src/io_module.f90
+++ b/src/io_module.f90
@@ -3378,6 +3378,9 @@ second:   do
   !!  MODIFICATION HISTORY
   !!   2011/10/20 09:59 dave
   !!    Syntax correction for rewind
+  !!   2024/05/21 TM
+  !!    Ordering has been changed from partition labeling to 
+  !!      ion_velocity -> atom_vel
   !!  SOURCE
   !!
   subroutine read_velocity(velocity, filename)
@@ -3392,24 +3395,15 @@ second:   do
     character(len=50),intent(in) :: filename
 
     ! Local variables
-    integer :: id_global, ni , ni2, id_tmp
-    integer :: lun
+    integer :: ni, id_tmp, lun
 
     if(inode == ionode) then
-       if(iprint_init>2) write(io_lun,'(10x,a40,a20)') 'Entering read_velocity; reading ', filename
+       if(iprint_init>2) write(io_lun,'(10x,a40,a20)') 'Entering NEW read_velocity; reading ', filename
        call io_assign(lun)
        open(unit=lun,file=filename)
        rewind(unit=lun)
-       do id_global=1,ni_in_cell
-          ni=id_glob_inv(id_global)
-          if(id_glob(ni) /= id_global) &
-               call cq_abort(' ERROR in global labelling ',id_global,id_glob(ni))
-          read(lun,101) id_tmp, ni2, velocity(1:3, ni)
-          if(ni2 /= ni) write(io_lun,fmt='(4x,a,i6,a,i6,a,i6)') &
-               ' Order of atom has changed for global id (file_labelling) = ',id_global, &
-               ' : corresponding labelling (NOprt labelling) used to be ',ni2,&
-               ' : but now it is ',ni
-101       format(2i8,3e20.12)
+       do ni=1,ni_in_cell
+          read(lun,*) id_tmp, velocity(1:3, ni)
        enddo
        call io_close(lun)
     endif  ! (inode == ionode) then

--- a/src/io_module.f90
+++ b/src/io_module.f90
@@ -3379,8 +3379,8 @@ second:   do
   !!   2011/10/20 09:59 dave
   !!    Syntax correction for rewind
   !!   2024/05/21 TM
-  !!    Ordering has been changed from partition labeling to 
-  !!      ion_velocity -> atom_vel
+  !!    Ordering has been changed from partition labeling to the globa one (in coordinate file)
+  !!    I assume the passed array will be changed from ion_velocity -> atom_vel
   !!  SOURCE
   !!
   subroutine read_velocity(velocity, filename)

--- a/src/md_misc_module.f90
+++ b/src/md_misc_module.f90
@@ -137,20 +137,24 @@ contains
        ! unified md checkpoint file easier - zamaan
        ion_velocity = zero
        if (flag_read_velocity) then
-          call read_velocity(ion_velocity, file_velocity)
+          !call read_velocity(ion_velocity, file_velocity)
+          call read_velocity(atom_vels, file_velocity)
+          do i=1,ni_in_cell
+            ion_velocity(1,i) = atom_vels(1,id_glob(i))
+            ion_velocity(2,i) = atom_vels(2,id_glob(i))
+            ion_velocity(3,i) = atom_vels(3,id_glob(i))
+          end do
        else
           if(temp_ion > RD_ERR) then
              call init_velocity(ni_in_cell, temp_ion, ion_velocity, ion_ke)
           end if
+          ! atom_vels : 2020/Jul/30 -> 2024/May/21
+          do i=1,ni_in_cell
+             atom_vels(1,id_glob(i)) = ion_velocity(1,i)
+             atom_vels(2,id_glob(i)) = ion_velocity(2,i)
+             atom_vels(3,id_glob(i)) = ion_velocity(3,i)
+          end do
        end if
-
-       ! atom_vels : 2020/Jul/30
-       do i=1,ni_in_cell
-          atom_vels(1,id_glob(i)) = ion_velocity(1,i)
-          atom_vels(2,id_glob(i)) = ion_velocity(2,i)
-          atom_vels(3,id_glob(i)) = ion_velocity(3,i)
-       end do
-
     end if
 
     if(leqi(md_thermo_type,'svr').AND.md_tau_T<zero) then


### PR DESCRIPTION
I have changed the format of "velocity.dat", which can provide the initial atomic velocity but has not been used recently.
The order of atoms in the file used to be "partition labelling" (depending on the distribution of atoms in small groups for parallelisation), but is now global labelling consistent with the order in the coordinate file.
 
Note that the order in "md.checkpoints", which is used to continue MD simulations, has not been changed yet.  (I think it is better to change it as well in the future. But, we should prepare an option to read the old version of the file.)