### PR TITLE
Specify integration grid spacing and k-point grid spacing

### DIFF
--- a/docs/convergence.rst
+++ b/docs/convergence.rst
@@ -36,7 +36,13 @@ cutoff is set with the parameter:
   Grid.GridCutoff E
 
 where ``E`` is an energy in Hartrees.  The grid spacing can also be
-set manually, by specifying the number of grid points in each
+set manually (in Bohr radii):
+
+ ::
+
+  Grid.GridSpacing d
+
+Or it can be set by specifying the number of grid points in each
 direction:
 
  ::

--- a/docs/groundstate.rst
+++ b/docs/groundstate.rst
@@ -101,6 +101,12 @@ arbitrary vector from the origin of the Brillouin zone, by specifying:
    Diag.MPShiftY 0.0
    Diag.MPShiftZ 0.0
 
+For the Monkhorst-Pack approach, instead of specifying the number of
+points in x, y and z explicitly, they can be set automatically by giving
+a spacing in reciprocal space: ``Diag.dk`` where units are inverse Bohr
+radii.  The number of points will be chosen so that :math:`2\pi/(a\times dk)`
+is less than the value specified.
+
 Alternatively, the points in reciprocal space can be specified
 explicitly by giving a number of points and their locations and weights:
 

--- a/docs/input-output.rst
+++ b/docs/input-output.rst
@@ -30,7 +30,7 @@ Full documentation can be found in :ref:`input_tags`.
   * ``Diag.MPMesh``   T/F
   * ``Diag.MPMeshX`` (and ``Y`` and ``Z``) N
   * ``Diag.GammaCentred`` T/F
-* ``Grid.GridCutoff`` Energy in Ha (sets a grid spacing :math:`\delta x = \pi/\sqrt{2E}` for cutoff E in Ha)
+* ``Grid.GridCutoff`` Energy in Ha (sets a grid spacing :math:`\delta x = \pi/\sqrt{2E}` for cutoff E in Ha; this spacing can also be set manually using ``Grid.GridSpacing`` in Bohr)
 * ``AtomMove.NumSteps`` N
 * ``AtomMove.MaxForceTol`` in Ha/bohr
 * ``AtomMove.OptCell`` T/F (optimises simulation cell size)

--- a/docs/input_tags.rst
+++ b/docs/input_tags.rst
@@ -668,7 +668,13 @@ Diag.GammaCentred (*boolean*)
     Selects Monkhorst-Pack mesh centred on the Gamma point
 
     *default*: F
-    
+
+Diag.dk (*real*)
+    Sets the number of k-points in the Monkhorst-Pack method so that the spacing
+    in reciprocal space is less than the specified value.
+
+    *default*: 0.0
+
 Diag.PaddingHmatrix (*boolean*)
     Setting this flag allows the Hamiltonian and overlap matrices to be 
     made larger than their physical size, so that ScaLAPACK block sizes can

--- a/docs/input_tags.rst
+++ b/docs/input_tags.rst
@@ -395,6 +395,12 @@ Grid.GridCutoff (*real*)
 
     Default: 50 Ha.
 
+Grid.GridSpacing (*real*)
+    As an alternative, the grid spacing in Bohr radii can be set (the code will determine a number
+    of grid points that will be below this value)
+
+    Default: zero (value taken from Grid.GridCutoff above)
+    
 Go to :ref:`top <input_tags>`.
 
 .. _input_minE:

--- a/src/initial_read_module.f90
+++ b/src/initial_read_module.f90
@@ -974,7 +974,7 @@ contains
     ! spin polarisation
     logical :: flag_spin_polarisation
     real(double) :: sum_elecN_spin
-    real(double) :: charge_tmp
+    real(double) :: charge_tmp, GridSpacing
 
     ! Set defaults
     vary_mu  = .true.
@@ -1159,7 +1159,12 @@ contains
     !
     !
     ! Default to 50 Ha cutoff for grid
-    GridCutoff = fdf_double('Grid.GridCutoff',50.0_double)
+    GridSpacing = fdf_double('Grid.GridSpacing',zero)
+    if(GridSpacing>zero) then
+       GridCutoff = half*(pi/GridSpacing)*(pi/GridSpacing)
+    else
+       GridCutoff = fdf_double('Grid.GridCutoff',50.0_double)
+    end if
     ! Grid points
     n_grid_x   = fdf_integer('Grid.PointsAlongX',0)
     n_grid_y   = fdf_integer('Grid.PointsAlongY',0)

--- a/src/initial_read_module.f90
+++ b/src/initial_read_module.f90
@@ -3016,7 +3016,7 @@ contains
     character(len=80) :: sub_name = "readDiagInfo"
     type(cq_timer) :: backtrace_timer
     integer        :: stat, i, j, k, nk_st, nkp_lines
-    real(double)   :: a, sum, dkx, dky, dkz
+    real(double)   :: a, sum, dkx, dky, dkz, dk
     integer        :: proc_per_group
     logical        :: ms_is_prime
     
@@ -3286,11 +3286,18 @@ contains
        ! Read Monkhorst-Pack mesh coefficients
        ! Default is Gamma point only 
        if(iprint_init>1.AND.inode==ionode) &
-            write(io_lun,fmt='(/8x,"Reading Monkhorst-Pack Kpoint mesh"//)')
+            write(io_lun,fmt='(/8x,"Using Monkhorst-Pack Kpoint mesh"//)')
        flag_gamma = fdf_boolean('Diag.GammaCentred',.false.)
-       mp(1) = fdf_integer('Diag.MPMeshX',1)
-       mp(2) = fdf_integer('Diag.MPMeshY',1)
-       mp(3) = fdf_integer('Diag.MPMeshZ',1) 
+       dk = fdf_double('Diag.dk',zero)
+       if(dk>zero) then
+          mp(1) = ceiling(two*pi/(dk*rcellx))
+          mp(2) = ceiling(two*pi/(dk*rcelly))
+          mp(3) = ceiling(two*pi/(dk*rcellz))
+       else
+          mp(1) = fdf_integer('Diag.MPMeshX',1)
+          mp(2) = fdf_integer('Diag.MPMeshY',1)
+          mp(3) = fdf_integer('Diag.MPMeshZ',1)
+       end if
        if(iprint_init>0.AND.inode==ionode) then
           if(flag_gamma) then
              write (io_lun,fmt='(/8x,a, i3," x ",i3," x ",i3," gamma-centred")') &


### PR DESCRIPTION
Added parameters to allow user to set the spacing for the integration grid and the Brillouin zone integration grid rather than number of points or energy.  Added documentation.