### PR TITLE
Save stress tensor in extXYZ file

### DIFF
--- a/src/io_module.f90
+++ b/src/io_module.f90
@@ -2900,7 +2900,7 @@ second:   do
     character(len=80)          :: titles_xyz
     character(len=135)         :: stress_str
 
-    real(double)               :: for_conv_loc, en_conv_loc, dist_conv_loc
+    real(double)               :: for_conv_loc, en_conv_loc, dist_conv_loc, volume
 
     if(inode==ionode) then
       if (iprint_init>2) write(io_lun, &
@@ -2935,10 +2935,18 @@ second:   do
       write(energy_str,'(f0.8)') energy0 * en_conv_loc
       comment = TRIM(comment)//TRIM(energy_str)//' pbc="T T T" '
 
+      volume = r_super_x*r_super_y*r_super_z*BohrToAng**3
+
       ! Convert each row to string
-      write(stress_str(1:45), '(3f15.8)') stress_tensor(1,1), stress_tensor(1,2), stress_tensor(1,3)
-      write(stress_str(46:90), '(3f15.8)') stress_tensor(2,1), stress_tensor(2,2), stress_tensor(2,3)
-      write(stress_str(91:135), '(3f15.8)') stress_tensor(3,1), stress_tensor(3,2), stress_tensor(3,3)
+      write(stress_str(1:45), '(3f15.8)') stress_tensor(1,1)*HaToeV/volume,&
+              stress_tensor(1,2)*HaToeV/volume,&
+              stress_tensor(1,3)*HaToeV/volume
+      write(stress_str(46:90), '(3f15.8)') stress_tensor(2,1)*HaToeV/volume,&
+              stress_tensor(2,2)*HaToeV/volume,&
+              stress_tensor(2,3)*HaToeV/volume
+      write(stress_str(91:135), '(3f15.8)') stress_tensor(3,1)*HaToeV/volume,&
+              stress_tensor(3,2)*HaToeV/volume,&
+              stress_tensor(3,3)*HaToeV/volume
       comment = TRIM(comment)//' stress=" '//TRIM(stress_str)//'" '
 
       write(lun,'(a)') TRIM(comment)

--- a/src/io_module.f90
+++ b/src/io_module.f90
@@ -2870,10 +2870,11 @@ second:   do
   !!  CREATION DATE
   !!   2021/10/18
   !!  MODIFICATION HISTORY
-  !!   
+  !!   2024/11/04 Augustin Lu
+  !!   Add stress tensor
   !!  SOURCE
   !!
-  subroutine write_extxyz(filename, energy0, atom_force)
+  subroutine write_extxyz(filename, energy0, atom_force, stress_tensor)
 
     use datatypes
     use timer_module
@@ -2889,6 +2890,7 @@ second:   do
     character(len=*)                      :: filename
     real(double)                          :: energy0
     real(double), dimension(3,ni_in_cell) :: atom_force
+    real(double), dimension(3,3)          :: stress_tensor
 
     ! Local variables
     integer                    :: lun, i, j, title_length
@@ -2896,6 +2898,8 @@ second:   do
     character(len=432)         :: comment
     character(len=45)          :: vec_a, vec_b, vec_c, energy_str
     character(len=80)          :: titles_xyz
+    character(len=135)         :: stress_str
+
     real(double)               :: for_conv_loc, en_conv_loc, dist_conv_loc
 
     if(inode==ionode) then
@@ -2930,6 +2934,13 @@ second:   do
       comment=TRIM(comment)//' Properties=species:S:1:pos:R:3:forces:R:3 potential_energy='
       write(energy_str,'(f0.8)') energy0 * en_conv_loc
       comment = TRIM(comment)//TRIM(energy_str)//' pbc="T T T" '
+
+      ! Convert each row to string
+      write(stress_str(1:45), '(3f15.8)') stress_tensor(1,1), stress_tensor(1,2), stress_tensor(1,3)
+      write(stress_str(46:90), '(3f15.8)') stress_tensor(2,1), stress_tensor(2,2), stress_tensor(2,3)
+      write(stress_str(91:135), '(3f15.8)') stress_tensor(3,1), stress_tensor(3,2), stress_tensor(3,3)
+      comment = TRIM(comment)//' stress=" '//TRIM(stress_str)//'" '
+
       write(lun,'(a)') TRIM(comment)
 
       do i=1,ni_in_cell

--- a/src/md_misc_module.f90
+++ b/src/md_misc_module.f90
@@ -257,7 +257,7 @@ contains
   !!   2020/10/07 tsuyoshi
   !!    added deallocation of atom_vels
   !!  SOURCE
-  !!  
+  !!
   subroutine end_md(th, baro)
 
     use GenComms,         only: inode, ionode
@@ -313,7 +313,7 @@ contains
   !!  CREATION DATE
   !!   2018/04/23 11:49
   !!  SOURCE
-  !!  
+  !!
   subroutine integrate_pt(baro, thermo, mdl, velocity, second_call)
 
     use numbers
@@ -551,8 +551,10 @@ contains
   !!  MODIFIED
   !!   2021/10/19 Jianbo Lin
   !!    Added call for extended XYZ output (includes forces)
+  !!   2024/11/04 Augustin Lu
+  !!    Added stress in call for extended XYZ output
   !!  SOURCE
-  !!  
+  !!
   subroutine write_md_data(iter, thermo, baro, mdl, nequil, MDfreq, XSFfreq, XYZfreq)
 
     use GenComms,      only: inode, ionode
@@ -582,7 +584,7 @@ contains
         call write_xsf(md_trajectory_file, iter)
     end if
     if (flag_write_extxyz .and. mod(iter,XYZfreq) == 0) then
-         call write_extxyz('trajectory.xyz', mdl%dft_total_energy, mdl%atom_force)
+         call write_extxyz('trajectory.xyz', mdl%dft_total_energy, mdl%atom_force, mdl%stress)
     end if
     if (flag_heat_flux) call mdl%dump_heat_flux(md_heat_flux_file)
     if (mod(iter, MDfreq) == 0) then


### PR DESCRIPTION
Close #378 

Add stress tensor in the comments of trajectory.xyz (unit: eV/ang**3).

This information can be read by other packages such as ASE.

Example below with a 8-atom Si cell (NPT).

Conquest_out:
```
      force: Maximum force :        0.05000631(Ha/a0) on atom         5 in z direction
      force: Force Residual:        0.04902342 Ha/a0
      force: Total stress:          0.74155321    -1.84331297     0.12191144 GPa

    MD step:     99 KE:         0.01448494 Ha IntEnergy:         -33.60117595 Ha TotalEnergy:         -33.58669101 Ha

      force: Maximum force :        0.04882996(Ha/a0) on atom         5 in z direction
      force: Force Residual:        0.04893222 Ha/a0
      force: Total stress:          1.38235123    -1.29514909     0.50513119 GPa

    MD step:    100 KE:         0.01443590 Ha IntEnergy:         -33.60778528 Ha TotalEnergy:         -33.59334938 Ha
```

trajectory.xyz:
```
8
config_type= Lattice="5.50541532     0.00000000     0.00000000     0.00000000     5.50541532     0.00000000     0.00000000     0.00000000     5.50541532" Properties=species:S:1:pos:R:3:forces:R:3 potential_energy=-914.33456941 pbc="T T T" stress="      0.00462841     0.00000000     0.00000000     0.00000000    -0.01150505     0.00000000     0.00000000     0.00000000     0.00076091"
  Si      5.03110541      5.38506756      5.22845718 -0.18617114E+01 -0.15170907E+01 -0.22133260E+01
  Si      2.75870416      2.76797928      5.46515464  0.90226801E+00  0.56898130E+00 -0.34902481E+00
  Si      2.89712039      5.19585901      2.91043075  0.17172608E+01 -0.19579072E+01  0.21126897E+01
  Si      0.08885933      2.72016595      2.70152288  0.95996331E+00  0.89109100E+00  0.67559888E+00
  Si      1.94790352      1.59155287      1.75630426  0.20379204E+01  0.14600916E+01  0.25714279E+01
  Si      4.04939920      3.95739064      1.41530062 -0.88250661E+00 -0.34564481E+00 -0.21941374E+00
  Si      1.31430491      4.15050224      4.17396457 -0.10978230E+01 -0.73287886E+00 -0.67533129E+00
  Si      3.88675248      1.70319388      3.80414078 -0.17644754E+01  0.16474557E+01 -0.19040854E+01
8
config_type= Lattice="5.51685178     0.00000000     0.00000000     0.00000000     5.51685178     0.00000000     0.00000000     0.00000000     5.51685178" Properties=species:S:1:pos:R:3:forces:R:3 potential_energy=-914.51441853 pbc="T T T" stress="      0.00862796     0.00000000     0.00000000     0.00000000    -0.00808368     0.00000000     0.00000000     0.00000000     0.00315278"
  Si      5.02731627      5.38223528      5.22412773 -0.18484208E+01 -0.16113975E+01 -0.22694932E+01
  Si      2.76083964      2.76925074      5.46510336  0.91441185E+00  0.59975061E+00 -0.34188339E+00
  Si      2.90065330      5.19179413      2.91461982  0.17488271E+01 -0.18838251E+01  0.21483447E+01
  Si      0.09139527      2.72223874      2.70287580  0.82127641E+00  0.84836310E+00  0.70325492E+00
  Si      1.95232365      1.59491703      1.76193152  0.20625112E+01  0.14495057E+01  0.25109372E+01
  Si      4.04706679      3.95624148      1.41411734 -0.85230660E+00 -0.37332125E+00 -0.16801157E+00
  Si      1.31155174      4.14848008      4.17228965 -0.11107098E+01 -0.65453118E+00 -0.64311793E+00
  Si      3.88300462      1.70655638      3.80021020 -0.17270122E+01  0.16197030E+01 -0.19561292E+01

```

