### PR TITLE
Add citations for LibXC

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -43,8 +43,10 @@ a working MPI installation including a Fortran90 compiler (often
   can be obtained from `the netlib repository <http://www.netlib.org/scalapack/>`_ if
   you need to compile it)
 
-Additionally, Conquest can use LibXC if it is available (v4.x or
-later).
+Additionally, Conquest can use `ELPA <https://elpa.mpcdf.mpg.de/index.html>`_ as an
+alternative to ScaLAPACK (with GPU implementations also available).
+It will also use `LibXC <https://libxc.gitlab.io/>`_ if it is
+available (v4.x or later) :cite:`i-Lehtola:2018le`.
 
 The library locations are set in the ``system.make`` file in the ``src/system``
 directory, along with other parameters needed for compilation.  The default file
@@ -223,5 +225,13 @@ Compile CONQUEST
 
     dos2unix ./makedeps       # For Windows Subsystem for Linux (WSL), there may be some incompatibilities thus file conversion is recommended.
     make                      # Or make -j`nproc` for parallel compilation using all available cores
+
 Go to :ref:`top <install>`
 
+.. bibliography:: references.bib
+    :cited:
+    :labelprefix: I
+    :keyprefix: i-
+    :style: unsrt
+
+Go to :ref:`top <install>`

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,11 +1,21 @@
 %% This BibTeX bibliography file was created using BibDesk.
-%% http://bibdesk.sourceforge.net/
+%% https://bibdesk.sourceforge.io/
 
-
-%% Created for David Bowler at 2019-12-20 09:46:12 +0000 
+%% Created for David Bowler at 2026-02-11 11:22:57 +0000 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
+
+
+
+@article{Lehtola:2018le,
+	author = {Lehtola, Susi and Steigemann, Conrad and Oliveira, Micael J. T. and Marques, Miguel A. L.},
+	doi = {10.1016/j.softx.2017.11.002},
+	journal = {SoftwareX},
+	pages = {1--5},
+	title = {Recent developments in libxc —A comprehensive library of functionals for density functional theory},
+	volume = {7},
+	year = {2018}}
 
 @article{Torralba:2009nr,
 	author = {Torralba, Antonio S and Bowler, David R and Miyazaki, Tsuyoshi and Gillan, Michael J},

--- a/src/XC_LibXC_v5_module.f90
+++ b/src/XC_LibXC_v5_module.f90
@@ -126,9 +126,9 @@ contains
        call xc_f03_version(vmajor, vminor, vmicro)
        if(inode==ionode.AND.iprint_ops>0) then
           if(vmajor>2) then
-             write(io_lun,'(4x,"LibXC version: ",I2,".",I2,".",I2)') vmajor, vminor, vmicro
+             write(io_lun,'(4x,"Using LibXC version: ",I2,".",I2,".",I2)') vmajor, vminor, vmicro
           else
-             write(io_lun,'(4x,"LibXC version: ",I2,".",I2)') vmajor, vminor
+             write(io_lun,'(4x,"Using LibXC version: ",I2,".",I2)') vmajor, vminor
           end if
        end if
        ! Identify the functional
@@ -313,15 +313,18 @@ contains
     implicit none
 
     integer :: i, j
-    character(len=120) :: ref
+    character(len=200) :: ref
 
+    call xc_f03_reference(ref)
+    write(io_lun,fmt='(/4x,"LibXC reference:  ",a)') ref
     write(io_lun,fmt='(4x,"XC references from LibXC:")')
     do j=1,n_xc_terms
        i = 0
        ref = xc_f03_func_reference_get_ref(xc_f03_func_info_get_references(xc_info(j),i))
+       write(io_lun,fmt='(6x,a)') trim(ref)
        do while(i >= 0)
-          write(io_lun, '(6x,a)') trim(ref)
           ref = xc_f03_func_reference_get_ref(xc_f03_func_info_get_references(xc_info(j),i))
+          write(io_lun, '(6x,a)') trim(ref)
        end do
     end do
     return


### PR DESCRIPTION
Citation for LibXC added to output file, and URL and citation added to manual (under Installation).  Added URL for ELPA at the same time.