### PR TITLE
Change of Becke charge output

### DIFF
--- a/src/density_module.f90
+++ b/src/density_module.f90
@@ -778,6 +778,8 @@ contains
   !!    Introduced matKatomf
   !!   2016/10/28 17:30 nakata
   !!    Introduce matK -> matKatomf transformations
+  !!   2026/04/23 16:20 nakata
+  !!    Removed call for build_Becke_charges for the density updated in each SCF step
   !!  SOURCE
   !!
   subroutine get_electronic_density(denout, electrons, atom_fns, &
@@ -881,9 +883,6 @@ contains
             write (io_lun, '(4x,a,i1,a,f25.15)') &
                   trim(prefix)//" Electrons (spin=",spin, "): ", electrons(spin)
     end do ! spin
-
-    if (flag_Becke_weights) &
-         call build_Becke_charges(atomcharge, denout, size)
 
     ! atom_fns_K is using the same memory as h_on_atomfns, (in other
     ! words we are using h_on_atomfns as temorary storage), so lets be
@@ -1974,6 +1973,8 @@ contains
   !!    Renamed naba_atm -> naba_atoms_of_blocks
   !!   2016/08/01 17:30 nakata
   !!    Introduced atomf instead of sf
+  !!   2026/04/23 16:20 nakata
+  !!    Changed to write out in BeckeCharge.dat
   !!  SOURCE
   !!
   subroutine build_Becke_charges(atomch, chden, size)
@@ -1989,6 +1990,7 @@ contains
     use dimens,              only: grid_point_volume
     use block_module,        only: n_pts_in_block
     use group_module,        only: parts
+    use io_module,           only: io_assign
 
     implicit none
 
@@ -1998,10 +2000,13 @@ contains
     real(double), dimension(:,:) :: chden
 
     ! Local variables
-    integer :: blk, no_of_ib_ia, at, point, ipos, spin
+    integer :: blk, no_of_ib_ia, at, point, ipos, spin, chun
     integer :: ipart, jpart, ind_part, ia, ii, icover, ig_atom, iatom, &
                iblock, the_species
     logical :: do_spin_down
+
+    if(inode==ionode.AND.iprint_SC>=2) &
+         write(io_lun,fmt='(2x,"Entering build_Becke_charges")')
 
     atomch = zero
     no_of_ib_ia = 0
@@ -2038,19 +2043,19 @@ contains
     do spin = 1, nspin
        atomch(:,spin) = atomch(:,spin) * grid_point_volume
        call gsum(atomch(:,spin), ni_in_cell)
+    enddo
+    do spin = 1, nspin
        ! print out the atom charge density information
-       if (inode == ionode .and. iprint_SC > 2) then
+       if (inode == ionode) then
+          call io_assign(chun)
+          open(unit = chun, file='BeckeCharge.dat')
           if (nspin == 1) then
              do blk = 1, ni_in_cell
-                write (io_lun, &
-                       fmt='(2x,"Atom ",i4," Becke charge ",f20.12)') &
-                       blk, spin_factor*atomch(blk,spin)
+                write (chun, fmt='(f15.10)') spin_factor*atomch(blk,1)
              end do
           else
              do blk = 1, ni_in_cell
-                write (io_lun, &
-                       fmt='(2x,"Atom ",i4," Becke charge (spin=",i1,") ",f20.12)') &
-                       blk, spin, atomch(blk,spin)
+                write (chun, fmt='(3f15.10)') atomch(blk,1)+atomch(blk,2), atomch(blk,1), atomch(blk,2)
              end do
           end if
        end if

--- a/src/initialisation_module.f90
+++ b/src/initialisation_module.f90
@@ -319,6 +319,8 @@ contains
   !!    Adding check for maximum angular momentum for Bessel functions
   !!   2022/06/09 08:36 dave
   !!    Change name of D2 set-up routine
+  !!   2026/04/23 16:20 nakata
+  !!    Removed call for build_Becke_charges for initial atomcharge
   !!  SOURCE
   !!
   subroutine set_up(find_chdens,level)
@@ -360,7 +362,6 @@ contains
     use density_module,         only: set_atomic_density, density,            &
                                       density_scale, atomcharge,       &
                                       build_Becke_weights,             &
-                                      build_Becke_charges,             &
                                       set_density_pcc, density_pcc,    &
                                       density_atom
     use block_module,           only: n_pts_in_block,     &
@@ -625,7 +626,7 @@ contains
                           ni_in_cell, stat)
       call reg_alloc_mem(area_init, nspin * ni_in_cell, type_dbl)
       call build_Becke_weights
-      call build_Becke_charges(atomcharge, density, maxngrid)
+      !call build_Becke_charges(atomcharge, density, maxngrid) # calculate becke charge for atomcharge
    end if
    if (inode == ionode .and. iprint_init > 2) &
         write (io_lun,fmt='(4x,a)') trim(prefix)//'Done init_pseudo '

--- a/src/minimise.f90
+++ b/src/minimise.f90
@@ -133,6 +133,8 @@ contains
   !!    Add call to new_SC_potl when doing MSSF/LFD without optimisation
   !!   2022/12/13 16:46 dave and tsuyoshi
   !!    Move output of wavefunctions and potential to be after final energy and force call
+  !!   2026/04/23 16:35 nakata
+  !!    Add call to build_becke_charges after converging SCF
   !!  SOURCE
   !!
   subroutine get_E_and_F(fixed_potential, vary_mu, total_energy, &
@@ -152,7 +154,7 @@ contains
                                  flag_multisite, iprint_minE,          &
                                  io_lun, flag_out_wf, wf_self_con, flag_write_projected_DOS, &
                                  flag_diagonalisation, nspin, flag_LFD, min_layer, &
-                                 flag_DM_converged, write_ase, flag_calc_pol
+                                 flag_DM_converged, write_ase, flag_calc_pol, flag_Becke_weights
     use energy,            only: get_energy, xc_energy, final_energy
     use GenComms,          only: cq_abort, inode, ionode, cq_warn
     use blip_minimisation, only: vary_support, dE_blip
@@ -160,7 +162,7 @@ contains
     use timer_module
     use input_module,      only: leqi
     use vdWDFT_module,     only: vdWXC_energy, vdWXC_energy_slow
-    use density_module,    only: density
+    use density_module,    only: density, atomcharge, build_Becke_charges
     use multisiteSF_module,only: flag_LFD_nonSCF, flag_mix_LFD_SCF
     use units
     use io_module,         only: return_prefix
@@ -378,6 +380,7 @@ contains
     if (flag_calc_pol) call get_polarisation()
     !
     if (atomch_output) call get_atomic_charge()
+    if (flag_Becke_weights) call build_Becke_charges(atomcharge, density, maxngrid)
 
     if (find_forces) then
        ! Start timing the force calculation


### PR DESCRIPTION
Changed Becke charge output to be written to BeckeCharge.dat only after SCF has converged.
This is related to the issue #449 .