### PR TITLE
Changed the default setting of flag_procwf_range_Ef to .true. for PDOS.

### DIFF
--- a/tools/PostProcessing/read_module.f90
+++ b/tools/PostProcessing/read_module.f90
@@ -283,7 +283,7 @@ contains
        end if
        flag_wf_range = .true.
        flag_wf_range_Ef = fdf_boolean('IO.WFRangeRelative',.true.)
-       flag_procwf_range_Ef = fdf_boolean('Process.WFRangeRelative',.false.)
+       flag_procwf_range_Ef = fdf_boolean('Process.WFRangeRelative',.true.)
        flag_l_resolved = fdf_boolean('Process.pDOS_l_resolved',.false.)
        flag_lm_resolved = fdf_boolean('Process.pDOS_lm_resolved',.false.)
        if(flag_lm_resolved .and. (.not.flag_l_resolved)) flag_l_resolved = .true.


### PR DESCRIPTION
The default setting of PostProcess for PDOS,
- flag_wf_range_Ef = fdf_boolean('IO.WFRangeRelative',.true.)
- flag_procwf_range_Ef = fdf_boolean('Process.WFRangeRelative',.false.)
would be good to be the same,
so the default setting of flag_procwf_range_Ef was changed to be .true.

This is related to the issue #451 .