### PR TITLE
Update RTD configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,8 +11,8 @@ build:
     python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
-#sphinx:
-#  configuration: docs/CONQUEST-manual/conf.py
+sphinx:
+  configuration: docs/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all


### PR DESCRIPTION
RTD now requires an explicit Sphinx configuration file: this change adds the manual configuration

NB As we are just changing configuration for documents, I'm not updating the version number.