### PR TITLE
Bug fix for DFT+U functionality

### DIFF
--- a/src/initialisation_module.f90
+++ b/src/initialisation_module.f90
@@ -335,7 +335,8 @@ contains
                                       nspin, min_layer,                &
                                       glob2node, flag_XLBOMD,          &
                                       flag_neutral_atom, flag_diagonalisation, &
-                                      flag_write_occ_mat, occ_mat, occ_mat_glob
+                                      flag_write_occ_mat, occ_mat, occ_mat_glob, &
+                                      flag_DFTplusU
     use memory_module,          only: reg_alloc_mem, reg_dealloc_mem,  &
                                       type_dbl, type_int
     use group_module,           only: parts
@@ -490,8 +491,10 @@ contains
     if (inode == ionode .and. iprint_init > 2) &
          write (io_lun,fmt='(4x,a)') trim(prefix)//'Made covering set for matrix multiplications'
 
-    allocate(occ_mat(7,7,bundle%n_prim,nspin))
-    if(flag_write_occ_mat) allocate(occ_mat_glob(7,7,ni_in_cell,nspin))
+    if(flag_DFTplusU) then
+       allocate(occ_mat(7,7,bundle%n_prim,nspin))
+       if(flag_write_occ_mat) allocate(occ_mat_glob(7,7,ni_in_cell,nspin))
+    end if
     ! Create all of the indexing required to perform matrix multiplications
     ! at a later point. This routine also identifies all the density
     ! matrix range interactions and hamiltonian range interactions

--- a/src/initialisation_module.f90
+++ b/src/initialisation_module.f90
@@ -493,7 +493,11 @@ contains
 
     if(flag_DFTplusU) then
        allocate(occ_mat(7,7,bundle%n_prim,nspin))
-       if(flag_write_occ_mat) allocate(occ_mat_glob(7,7,ni_in_cell,nspin))
+       occ_mat = zero
+       if(flag_write_occ_mat) then
+          allocate(occ_mat_glob(7,7,ni_in_cell,nspin))
+          occ_mat_glob = zero
+       end if
     end if
     ! Create all of the indexing required to perform matrix multiplications
     ! at a later point. This routine also identifies all the density

--- a/src/move_atoms.module.f90
+++ b/src/move_atoms.module.f90
@@ -3692,6 +3692,7 @@ contains
     if(flag_DFTplusU) then
        deallocate(occ_mat)
        allocate(occ_mat(7,7,bundle%n_prim,nspin))
+       occ_mat = zero
     end if
     ! (0) Pseudopotentials: choose correct form
     select case (pseudo_type)

--- a/src/move_atoms.module.f90
+++ b/src/move_atoms.module.f90
@@ -3661,7 +3661,10 @@ contains
                                       flag_SFcoeffReuse, flag_diagonalisation, &
                                       ne_spin_in_cell,                 &
                                       ne_in_cell, spin_factor,         &
-                                      ni_in_cell, area_moveatoms
+                                      ni_in_cell, area_moveatoms, &
+                                      flag_write_occ_mat, occ_mat, &
+                                      flag_DFTplusU
+    use primary_module,         only: bundle
     use density_module,         only: set_atomic_density,              &
                                       density, set_density_pcc,        &
                                       get_electronic_density
@@ -3685,6 +3688,11 @@ contains
     integer :: spin_SF, spin, stat
 
     call start_timer(tmr_l_tmp1,WITH_LEVEL)
+    ! Update DFT+U occupation matrix
+    if(flag_DFTplusU) then
+       deallocate(occ_mat)
+       allocate(occ_mat(7,7,bundle%n_prim,nspin))
+    end if
     ! (0) Pseudopotentials: choose correct form
     select case (pseudo_type)
     case (OLDPS)

--- a/src/pao2blip.f90
+++ b/src/pao2blip.f90
@@ -806,7 +806,7 @@ contains
        scal_prod_sym(n) = scal_prod(m)/coeff(n)
     end do
     if((inode == ionode).and.(iprint_basis >= 4)) then
-       write(unit=io_lun,fmt='(/6x" symmetric scalar product:"/)')
+       write(unit=io_lun,fmt='(/6x," symmetric scalar product:"/)')
        do n = 1, n_star_in_sphere
           write(unit=io_lun,fmt='(6x,3x,i5,3x,e15.6)') n, scal_prod_sym(n)
        end do


### PR DESCRIPTION
The occupation matrix can cause an array overflow when atoms move using DFT+U; this fixes the problem.