### PR TITLE
Initialize eri_gto to zero.

### DIFF
--- a/src/exx_erigto.f90
+++ b/src/exx_erigto.f90
@@ -666,6 +666,8 @@ contains
     
     real(double), dimension(5) :: F
 
+    eri_gto = zero
+
     i_nt = trim(gto( i_nsp )%sf( i )%nt)
     j_nt = trim(gto( j_nsp )%sf( j )%nt)
     k_nt = trim(gto( k_nsp )%sf( k )%nt)


### PR DESCRIPTION
This pull request adds zero initialization for variable `eri_gto`. 

This solves #466 

Results on Mac OS are now consistent with the reference value:
`Conquest_out:      |* Harris-Foulkes energy   =       -13.983024122321860 Ha`
`Conquest_out.ref:      |* Harris-Foulkes energy   =       -13.983024122331756 Ha`