### PR TITLE
F fix ig cover

### DIFF
--- a/src/cover_module.f90
+++ b/src/cover_module.f90
@@ -367,6 +367,7 @@ contains
        allocate(set%ig_cover(set%mx_mcover),STAT=stat)
        if(stat/=0) call cq_abort('Error allocating ig_cover:',set%mx_mcover,stat)
        call reg_alloc_mem(area_index, 3*set%mx_mcover,type_dbl)
+       call reg_alloc_mem(area_index, set%mx_mcover, type_int)   ! ig_cover: INTEGER(mx_mcover)
        call stop_timer(tmr_std_allocation)
        do ind_cover=1,set%ng_cover
           nsx=nx_in_cover(ind_cover)
@@ -846,7 +847,7 @@ contains
     use basic_types
     use GenComms, ONLY: cq_abort
     use global_module, ONLY: area_index
-    use memory_module, ONLY: reg_dealloc_mem, type_int
+    use memory_module, ONLY: reg_dealloc_mem, type_int, type_dbl
 
     implicit none
 
@@ -872,6 +873,8 @@ contains
     if(members) then
        deallocate(set%ig_cover,set%zcover,set%ycover,set%xcover, set%icover_ibeg,set%n_ing_cover, STAT=stat)
        if(stat/=0) call cq_abort('deallocate_cs: error(3)')
+       call reg_dealloc_mem(area_index, 3*set%mx_mcover, type_dbl)
+       call reg_dealloc_mem(area_index, set%mx_mcover, type_int)
     endif
     call stop_timer(tmr_std_allocation)
     return

--- a/src/cover_module.f90
+++ b/src/cover_module.f90
@@ -836,6 +836,8 @@ contains
 !!   2018/09/06 10:35 dave
 !!    Tidying and bug fix: members was bracketing ALL variables and
 !!    stat wasn't initialised  
+!!   2026/08/25 Augustin Lu
+!!    Added deallocation of ig_cover
 !!  SOURCE
 !!
   subroutine deallocate_cs(set,members)
@@ -868,7 +870,7 @@ contains
     deallocate(set%ncover_rem, set%inv_lab_cover, set%lab_cover,set%lab_cell, STAT=stat)
     if(stat/=0) call cq_abort('deallocate_cs: error(2)')
     if(members) then
-       deallocate(set%zcover,set%ycover,set%xcover, set%icover_ibeg,set%n_ing_cover, STAT=stat)
+       deallocate(set%ig_cover,set%zcover,set%ycover,set%xcover, set%icover_ibeg,set%n_ing_cover, STAT=stat)
        if(stat/=0) call cq_abort('deallocate_cs: error(3)')
     endif
     call stop_timer(tmr_std_allocation)


### PR DESCRIPTION
Partially solves the memory leakage mentioned in #471 

The effect is more visible when using a lower number of processes.

<img width="1321" height="1118" alt="image" src="https://github.com/user-attachments/assets/336eef03-27cb-4b1b-a8d4-bebfbd7c83b2" />

<img width="1321" height="1118" alt="image" src="https://github.com/user-attachments/assets/96b28a62-3dd4-4307-a122-72a8bef500b5" />

Originally, set%ig_cover did not get properly deallocated.

A minor additional fix has been added for the memory counting part (not linked to the memory leak)