### PR TITLE
Fix memory leak by deallocating S_X_SX comms data in fmmi()

### DIFF
--- a/src/mult_module.f90
+++ b/src/mult_module.f90
@@ -1206,6 +1206,8 @@ contains
   !!    Adding dissociate_matrices and deallocation of mat for empty bundle fix
   !!   2024/06/12 18:00 nakata
   !!    Adding end_ops for SXrange and Xrange
+  !!   2026/08/26 Augustin Lu
+  !!    Added deallocation of S_X_SX (fix for memory leak)
   !!  SOURCE
   !!
   subroutine fmmi(prim)
@@ -1408,6 +1410,7 @@ contains
     call deallocate_comms_data(mult(T_H_TH)%comms)
     call deallocate_comms_data(mult(T_L_TL)%comms)
     call deallocate_comms_data(mult(TL_T_L)%comms)
+    call deallocate_comms_data(mult(S_X_SX)%comms)
     if (atomf.ne.sf) then
        call deallocate_comms_data(mult(aSa_sCaTr_aSs)%comms)
        call deallocate_comms_data(mult(sCa_aSs_sSs)%comms)


### PR DESCRIPTION
This fix adds the missing call to deallocate S_X_SX's comms data in fmmi(). Without it, that comms structure is orphaned every step, and used memory grows linearly with simulation time in MD as well as geometry-optimisation runs.

The memory leak reported in #471 is confirmed suppressed on two different systems, and with different numbers of processes.

<img width="1321" height="1118" alt="system_1_128core" src="https://github.com/user-attachments/assets/e77b443b-7a45-4d17-97b6-e05697c8fdde" />
<img width="1321" height="1118" alt="system_1_32core" src="https://github.com/user-attachments/assets/bfa06d9b-6266-4152-a22f-ab3792c57ff0" />
<img width="1321" height="1118" alt="system_2_48core" src="https://github.com/user-attachments/assets/b7f5a18b-596a-415f-b6f3-b27cef8b0c39" />

Checks with SZP, DZP and TZTP also show similar original memory leak and its suppression by the present fix.
The fix is confirmed to have no impact on the simulation results.